### PR TITLE
fix(templates): commentaires de script affichés en bas de page (multi-ligne {# #})

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -156,16 +156,20 @@
         {% block content %}{% endblock %}
     </main>
     {% include 'partials/footer.html' %}
-    {# ⚠️ ORDRE CRITIQUE : app.js enregistre les composants Alpine via l'évènement
+    {% comment %}
+       ORDRE CRITIQUE : app.js enregistre les composants Alpine via l'évènement
        `alpine:init`. Il DOIT être chargé AVANT le script Alpine (les scripts defer
        s'exécutent dans l'ordre du document, et Alpine démarre dès son exécution).
        Sinon les composants (faqAccordion, clientPortal, …) ne sont pas enregistrés
-       à temps → accordéons/portail cassés. Ne pas déplacer après Alpine. #}
+       à temps → accordéons/portail cassés. Ne pas déplacer après Alpine.
+    {% endcomment %}
     <script defer src="{% static 'js/app.js' %}" nonce="{{ request.csp_nonce }}"></script>
-    {# 🔻 CSP : templates migrés au sous-ensemble CSP (Alpine.data + méthodes).
+    {% comment %}
+       CSP : templates migrés au sous-ensemble CSP (Alpine.data + méthodes).
        Bascule pilotée par env (cf. config/settings/base.py) :
          ALPINE_CSP_BUILD=1 → build @alpinejs/csp + retrait auto de 'unsafe-eval'.
-       Activer uniquement après QA navigateur. ALPINE_CSP_SRI = hash optionnel. #}
+       Activer uniquement après QA navigateur. ALPINE_CSP_SRI = hash optionnel.
+    {% endcomment %}
     {% if alpine_csp_build %}
     <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/csp@{{ alpine_version }}/dist/cdn.min.js" nonce="{{ request.csp_nonce }}"{% if alpine_csp_sri %} integrity="{{ alpine_csp_sri }}" crossorigin="anonymous"{% endif %}></script>
     {% else %}


### PR DESCRIPTION
## Problème

Après le merge de #17, deux commentaires `{# … #}` multi-lignes ajoutés dans `templates/base.html` **s'affichent en clair en bas de page** (texte « ⚠️ ORDRE CRITIQUE… » et « 🔻 CSP… » visible dans le footer sur mobile et desktop).

**Cause :** la syntaxe de commentaire Django `{# #}` ne supporte **qu'une seule ligne**. Un `{# #}` qui s'étend sur plusieurs lignes n'est pas reconnu comme commentaire et est rendu comme du **texte brut**.

Le correctif (`19f7aa0`) avait été poussé sur la branche **juste après** le merge de #17, il n'a donc jamais atteint `main`.

## Correctif

Conversion des deux blocs en `{% comment %}…{% endcomment %}`, qui gère le multi-ligne et est **toujours retiré du rendu**. Le contenu documentaire (ordre de chargement Alpine, bascule CSP) est conservé dans le source mais n'apparaît plus sur la page.

## Vérifications

- Moteur de template Django : `{% comment %}` multi-ligne → texte **absent** du rendu ✅
- Scan de tous les templates : **0** commentaire `{# #}` multi-ligne restant
- `manage.py check` : 0 issue

Après merge + redéploiement Render, le texte parasite disparaît du site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEhrMgmaMpC5ZqRz92S7Eu)_

## Summary by Sourcery

Bug Fixes:
- Ensure multi-line documentation comments in base.html no longer appear as plain text on rendered pages by converting them to {% comment %} blocks.