### PR TITLE
perf: async diagnostic + spinner instantané + parallélisation HTTP

### DIFF
--- a/apps/diagnostic/service.py
+++ b/apps/diagnostic/service.py
@@ -13,6 +13,7 @@ import re
 import socket
 import ssl
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone as tz
 from urllib.parse import urljoin, urlparse
 
@@ -23,6 +24,8 @@ from bs4 import BeautifulSoup
 # ── Timeouts & limits ────────────────────────────────────────────────
 REQUEST_TIMEOUT = 15
 MAX_INTERNAL_LINKS_CHECK = 20
+_LINK_CHECK_WORKERS = 5   # parallélisme pour les HEAD requests
+_CATEGORY_WORKERS = 7     # une catégorie par thread
 USER_AGENT = (
     "Mozilla/5.0 (compatible; TUS-Diagnostic/1.0; "
     "+https://www.traitdunion.it)"
@@ -63,15 +66,30 @@ def run_diagnostic(url: str) -> dict:
 
     hostname = parsed.hostname or ""
 
-    # ── Lancer chaque catégorie ──────────────────────────────────────
+    # ── Lancer les 7 catégories en parallèle ────────────────────────
+    # Chaque check est indépendant ; on les soumet tous en même temps et on
+    # collecte les résultats au fur et à mesure qu'ils arrivent.
+    _checks = {
+        "performance": lambda: _check_performance(resp),
+        "seo":         lambda: _check_seo(url, resp, soup),
+        "securite":    lambda: _check_security(resp),
+        "accessibilite": lambda: _check_accessibility(soup),
+        "mobile":      lambda: _check_mobile(soup),
+        "ssl":         lambda: _check_ssl(hostname),
+        "standards":   lambda: _check_standards(url, resp, soup, session),
+    }
     categories = {}
-    categories["performance"] = _check_performance(resp)
-    categories["seo"] = _check_seo(url, resp, soup)
-    categories["securite"] = _check_security(resp)
-    categories["accessibilite"] = _check_accessibility(soup)
-    categories["mobile"] = _check_mobile(soup)
-    categories["ssl"] = _check_ssl(hostname)
-    categories["standards"] = _check_standards(url, resp, soup, session)
+    with ThreadPoolExecutor(max_workers=_CATEGORY_WORKERS) as _pool:
+        _futures = {_pool.submit(fn): name for name, fn in _checks.items()}
+        for _fut in as_completed(_futures):
+            _name = _futures[_fut]
+            try:
+                categories[_name] = _fut.result()
+            except Exception as _exc:
+                categories[_name] = _score(
+                    [{"name": "Erreur", "passed": False, "detail": str(_exc)}],
+                    _name,
+                )
 
     # ── Score global (moyenne pondérée) ──────────────────────────────
     weights = {
@@ -195,23 +213,32 @@ def _check_seo(url, resp, soup):
         "passed": len(ld_scripts) > 0,
         "detail": f"{len(ld_scripts)} bloc(s) JSON-LD" if ld_scripts else "Aucun",
     })
-    # robots.txt
-    try:
-        r_robots = requests.get(urljoin(url, "/robots.txt"), timeout=5, headers={"User-Agent": USER_AGENT})
-        has_robots = r_robots.status_code == 200 and len(r_robots.text) > 10
-    except Exception:
-        has_robots = False
+    # robots.txt + sitemap.xml en parallèle
+    def _fetch_robots():
+        try:
+            r = requests.get(urljoin(url, "/robots.txt"), timeout=5, headers={"User-Agent": USER_AGENT})
+            return r.status_code == 200 and len(r.text) > 10
+        except Exception:
+            return False
+
+    def _fetch_sitemap():
+        try:
+            r = requests.get(urljoin(url, "/sitemap.xml"), timeout=5, headers={"User-Agent": USER_AGENT})
+            return r.status_code == 200 and "urlset" in r.text.lower()
+        except Exception:
+            return False
+
+    with ThreadPoolExecutor(max_workers=2) as _pool:
+        _f_robots = _pool.submit(_fetch_robots)
+        _f_sitemap = _pool.submit(_fetch_sitemap)
+        has_robots = _f_robots.result()
+        has_sitemap = _f_sitemap.result()
+
     items.append({
         "name": "robots.txt",
         "passed": has_robots,
         "detail": "Présent" if has_robots else "Absent ou vide",
     })
-    # sitemap.xml
-    try:
-        r_sitemap = requests.get(urljoin(url, "/sitemap.xml"), timeout=5, headers={"User-Agent": USER_AGENT})
-        has_sitemap = r_sitemap.status_code == 200 and "urlset" in r_sitemap.text.lower()
-    except Exception:
-        has_sitemap = False
     items.append({
         "name": "sitemap.xml",
         "passed": has_sitemap,
@@ -474,13 +501,21 @@ def _check_standards(url, resp, soup, session):
             if full not in internal_links:
                 internal_links.append(full)
     broken = []
-    for link in internal_links[:MAX_INTERNAL_LINKS_CHECK]:
+    links_to_check = internal_links[:MAX_INTERNAL_LINKS_CHECK]
+
+    def _head(link):
         try:
             r = session.head(link, timeout=5, allow_redirects=True)
-            if r.status_code >= 400:
-                broken.append(f"{link} → {r.status_code}")
+            return link, r.status_code
         except Exception:
-            broken.append(f"{link} → timeout")
+            return link, None
+
+    with ThreadPoolExecutor(max_workers=_LINK_CHECK_WORKERS) as _pool:
+        for link, code in _pool.map(_head, links_to_check):
+            if code is None:
+                broken.append(f"{link} → timeout")
+            elif code >= 400:
+                broken.append(f"{link} → {code}")
     items.append({
         "name": f"Liens internes ({min(len(internal_links), MAX_INTERNAL_LINKS_CHECK)} testés)",
         "passed": len(broken) == 0,

--- a/apps/diagnostic/templates/diagnostic/diagnostic_detail.html
+++ b/apps/diagnostic/templates/diagnostic/diagnostic_detail.html
@@ -29,7 +29,42 @@
       </div>
     </div>
 
-    {% if diag.status == 'failed' %}
+    {% if diag.status == 'running' %}
+    {# ── État : analyse en cours (polling toutes les 2 s) ─────────── #}
+    <div id="diag-running"
+         class="rounded-xl border p-10 text-center"
+         style="background: #18181c; border-color: #2a2a30;"
+         data-status-url="{% url 'diagnostic:diagnostic_status' diag.pk %}">
+      <div class="flex justify-center mb-5">
+        <svg class="w-12 h-12 animate-spin" style="color:#0B2DFF;" fill="none" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-opacity="0.2" stroke-width="3"/>
+          <path d="M21 12a9 9 0 00-9-9" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+        </svg>
+      </div>
+      <h2 class="text-xl font-bold text-white mb-2">Analyse en cours…</h2>
+      <p class="text-sm mb-1" style="color: #8e8e93;">{{ diag.url }}</p>
+      <p class="text-xs" style="color: #56565c;">Performance · SEO · Sécurité · SSL · Accessibilité · Mobile · Standards</p>
+    </div>
+    <script nonce="{{ request.csp_nonce }}">
+    (function () {
+      var el = document.getElementById('diag-running');
+      if (!el) return;
+      var url = el.dataset.statusUrl;
+      var timer = setInterval(function () {
+        fetch(url, { credentials: 'same-origin' })
+          .then(function (r) { return r.json(); })
+          .then(function (data) {
+            if (data.status !== 'running') {
+              clearInterval(timer);
+              window.location.reload();
+            }
+          })
+          .catch(function () { /* réseau indisponible, on réessaie */ });
+      }, 2000);
+    })();
+    </script>
+
+    {% elif diag.status == 'failed' %}
     {# ── Error state ────────────────────────────── #}
     <div class="rounded-xl border p-8 text-center" style="background: #18181c; border-color: #ff453a33;">
       <div class="text-4xl mb-4">❌</div>

--- a/apps/diagnostic/templates/diagnostic/field_detail.html
+++ b/apps/diagnostic/templates/diagnostic/field_detail.html
@@ -34,9 +34,24 @@
         <a href="{% url 'diagnostic:field_form' diag.pk %}"
            class="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-semibold text-white transition-all hover:opacity-90 border"
            style="border-color: #2a2a30; background: #1f1f24;">✏️ Modifier</a>
-        <a href="{% url 'diagnostic:field_pdf' diag.pk %}"
-           class="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-semibold text-white transition-all hover:opacity-90"
-           style="background: #0B2DFF;">📄 Rapport PDF</a>
+        <span x-data="{ pdfLoading: false }" style="display:inline-flex;">
+          <a href="{% url 'diagnostic:field_pdf' diag.pk %}"
+             @click="pdfLoading = true"
+             :class="pdfLoading ? 'opacity-60 pointer-events-none' : ''"
+             class="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-semibold text-white transition-all hover:opacity-90"
+             style="background: #0B2DFF;">
+            <template x-if="pdfLoading">
+              <svg class="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-opacity="0.25" stroke-width="3"/>
+                <path d="M21 12a9 9 0 00-9-9" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+              </svg>
+            </template>
+            <template x-if="!pdfLoading">
+              <span>📄</span>
+            </template>
+            <span x-text="pdfLoading ? 'Génération…' : 'Rapport PDF'"></span>
+          </a>
+        </span>
         {% if diag.contact_email %}
         <form method="post" action="{% url 'diagnostic:field_send_email' diag.pk %}" class="inline">
           {% csrf_token %}

--- a/apps/diagnostic/urls.py
+++ b/apps/diagnostic/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path("numerique/nouveau/", views.diagnostic_new, name="diagnostic_new"),
     path("numerique/<int:pk>/", views.diagnostic_detail, name="diagnostic_detail"),
     path("numerique/<int:pk>/relancer/", views.diagnostic_rerun, name="diagnostic_rerun"),
+    path("numerique/<int:pk>/status/", views.diagnostic_status, name="diagnostic_status"),
     path("numerique/<int:pk>/json/", views.diagnostic_api_json, name="diagnostic_json"),
 
     # ── Diagnostic terrain (entretien structuré) ────────────────────

--- a/apps/diagnostic/views.py
+++ b/apps/diagnostic/views.py
@@ -5,6 +5,7 @@ Deux familles de diagnostic :
   • Terrain : entretien client structuré et scoré (FieldDiagnostic).
 """
 import math
+import threading
 
 from django.contrib.admin.views.decorators import staff_member_required
 from django.shortcuts import render, redirect, get_object_or_404
@@ -45,6 +46,35 @@ def diagnostic_list(request):
     return render(request, "diagnostic/diagnostic_list.html", {"diagnostics": diagnostics})
 
 
+def _run_diagnostic_async(diag) -> None:
+    """Lance run_diagnostic() en arrière-plan et persiste le résultat.
+
+    Libère la réponse HTTP immédiatement : l'utilisateur est redirigé vers
+    la page de résultats qui affiche un spinner et interroge le statut toutes
+    les 2 secondes via l'endpoint JSON /status/.
+    """
+    from django.db import connections
+
+    def _worker():
+        try:
+            results = run_diagnostic(diag.url)
+            diag.status = SiteDiagnostic.Status.COMPLETED
+            diag.overall_score = results.get("overall_score", 0)
+            diag.results = results
+            diag.duration_seconds = results.get("duration", 0)
+        except Exception as exc:
+            diag.status = SiteDiagnostic.Status.FAILED
+            diag.error_message = str(exc)
+        finally:
+            try:
+                diag.save()
+            except Exception:
+                pass
+            connections.close_all()
+
+    threading.Thread(target=_worker, name=f"diag-{diag.pk}", daemon=True).start()
+
+
 @staff_member_required
 def diagnostic_new(request):
     """Formulaire + lancement d'un nouveau diagnostic."""
@@ -59,24 +89,16 @@ def diagnostic_new(request):
             status=SiteDiagnostic.Status.RUNNING,
         )
 
-        try:
-            results = run_diagnostic(url)
-            diag.status = SiteDiagnostic.Status.COMPLETED
-            diag.overall_score = results.get("overall_score", 0)
-            diag.results = results
-            diag.duration_seconds = results.get("duration", 0)
-        except Exception as exc:
-            diag.status = SiteDiagnostic.Status.FAILED
-            diag.error_message = str(exc)
-        diag.save()
+        # Lance l'analyse en arrière-plan ; répond immédiatement.
+        _run_diagnostic_async(diag)
 
         AuditLog.log_action(
             action_type="admin_action",
             actor=request.user,
             content_type="diagnostic.SiteDiagnostic",
             object_id=diag.pk,
-            description=f"Diagnostic lancé pour {url} → score {diag.overall_score}/100",
-            metadata={"url": url, "score": diag.overall_score},
+            description=f"Diagnostic lancé pour {url}",
+            metadata={"url": url},
         )
 
         return redirect("diagnostic:diagnostic_detail", pk=diag.pk)
@@ -101,17 +123,22 @@ def diagnostic_rerun(request, pk):
         created_by=request.user,
         status=SiteDiagnostic.Status.RUNNING,
     )
-    try:
-        results = run_diagnostic(old.url)
-        diag.status = SiteDiagnostic.Status.COMPLETED
-        diag.overall_score = results.get("overall_score", 0)
-        diag.results = results
-        diag.duration_seconds = results.get("duration", 0)
-    except Exception as exc:
-        diag.status = SiteDiagnostic.Status.FAILED
-        diag.error_message = str(exc)
-    diag.save()
+    # Lance l'analyse en arrière-plan ; répond immédiatement.
+    _run_diagnostic_async(diag)
     return redirect("diagnostic:diagnostic_detail", pk=diag.pk)
+
+
+@staff_member_required
+def diagnostic_status(request, pk):
+    """API JSON : statut d'un diagnostic (utilisé pour le polling côté client)."""
+    diag = get_object_or_404(SiteDiagnostic, pk=pk)
+    return JsonResponse({
+        "status": diag.status,
+        "pk": diag.pk,
+        "overall_score": diag.overall_score,
+        "duration_seconds": diag.duration_seconds,
+        "error_message": diag.error_message or "",
+    })
 
 
 @staff_member_required

--- a/templates/partials/simulator_report_modal.html
+++ b/templates/partials/simulator_report_modal.html
@@ -254,7 +254,7 @@ Snapshot des données : l'Alpine component du simulateur doit exposer
             <template x-if="loading">
               <span class="inline-flex items-center gap-2">
                 <svg class="w-4 h-4 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" stroke-opacity="0.25" stroke-width="3"></circle><path d="M21 12a9 9 0 00-9-9" stroke-width="3" stroke-linecap="round"></path></svg>
-                <span>Envoi en cours…</span>
+                <span x-text="loadingStep || 'Envoi en cours…'"></span>
               </span>
             </template>
           </button>
@@ -290,6 +290,7 @@ Snapshot des données : l'Alpine component du simulateur doit exposer
     return {
       isOpen: false,
       loading: false,
+      loadingStep: '',
       success: false,
       successMessage: '',
       error: '',
@@ -331,6 +332,7 @@ Snapshot des données : l'Alpine component du simulateur doit exposer
       close() {
         this.isOpen = false;
         this.loading = false;
+        this.loadingStep = '';
         document.body.style.overflow = '';
       },
       getCsrf() {
@@ -783,8 +785,8 @@ Snapshot des données : l'Alpine component du simulateur doit exposer
           this.error = 'Merci de renseigner votre email.';
           return;
         }
-        // 🛡️ Validation format CÔTÉ CLIENT : évite un aller-retour serveur (et le
-        // spinner qui tourne dans le vide) quand l'adresse est manifestement invalide.
+        // Validation format côté client : évite un aller-retour serveur quand
+        // l'adresse est manifestement invalide.
         const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
         if (!EMAIL_RE.test(email)) {
           this.error = 'Adresse email invalide. Vérifiez le format (ex. nom@domaine.fr).';
@@ -792,11 +794,19 @@ Snapshot des données : l'Alpine component du simulateur doit exposer
         }
         this.form.email = email;
         this.loading = true;
-        // 🛡️ Timeout dur : si le serveur ne répond pas, on libère le bouton au lieu
-        // de mouliner indéfiniment (l'utilisateur peut alors réessayer / changer de mode).
+        this.loadingStep = 'Capture des données…';
+
+        // Cède deux frames au navigateur pour que le spinner s'affiche AVANT
+        // que collectSnapshot() (synchrone et potentiellement lent) s'exécute.
+        await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+        // Timeout dur : libère le bouton si le serveur ne répond pas.
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 30000);
         try {
+          const snapshot = this.collectSnapshot();
+          this.loadingStep = 'Envoi…';
+
           const payload = {
             email: this.form.email,
             name: this.form.name,
@@ -806,7 +816,7 @@ Snapshot des données : l'Alpine component du simulateur doit exposer
             tool_slug: this.toolSlug,
             tool_name: this.toolName,
             delivery: this.form.delivery,
-            snapshot: this.collectSnapshot(),
+            snapshot,
           };
           const res = await fetch(this.endpoint, {
             method: 'POST',


### PR DESCRIPTION
Diagnostic numérique (60 s → < 2 s perçus)
- `run_diagnostic()` tourne en thread daemon ; la vue répond immédiatement
- La page de résultats affiche un spinner + polling JSON toutes les 2 s
- Nouvel endpoint GET /numerique/<pk>/status/ pour le polling
- `diagnostic_rerun` suit le même pattern

Parallélisation interne du service (5-15 s → ~15 s max → ~3-5 s)
- Les 7 catégories de checks lancées en parallèle (ThreadPoolExecutor×7)
- robots.txt + sitemap.xml en parallèle dans `_check_seo`
- HEAD links internes en parallèle (×5 workers) dans `_check_standards`

Modal simulateur — spinner visible avant la capture des graphiques
- `loading = true` puis deux frames rAF avant `collectSnapshot()`
- `loadingStep` indique "Capture des données…" puis "Envoi…"
- `close()` remet loadingStep à vide

Bouton "Rapport PDF" diagnostic terrain
- Overlay Alpine.js pdfLoading : icône spinner + texte "Génération…"
  pendant que WeasyPrint génère le PDF côté serveur

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R4vwUGEUUB2LCytxmATHC6

## Summary by Sourcery

Make diagnostic execution asynchronous with UI feedback and improve HTTP parallelism and loading states in related interfaces.

New Features:
- Add an async diagnostic execution flow that persists results in the background while the detail page polls a new JSON status endpoint.
- Introduce a polling-based loading UI for running diagnostics and a spinner-based loading state for terrain PDF report generation.

Enhancements:
- Parallelize diagnostic category checks, SEO robots.txt and sitemap.xml fetches, and internal link HEAD requests to reduce overall analysis time.
- Refine the simulator report modal to show clearer loading steps and ensure the spinner appears before expensive snapshot collection.