### PR TITLE
fix(simulateur): téléchargement PDF rejeté à cause des graphiques

### DIFF
--- a/apps/simulateur/forms.py
+++ b/apps/simulateur/forms.py
@@ -12,6 +12,13 @@ class SimulatorReportForm(forms.ModelForm):
     Le champ `website` est un honeypot anti-bot (doit rester vide).
     """
 
+    # Budget global des graphiques (base64) transmis au PDF. Les graphiques
+    # exportés en haute résolution pèsent 100-500KB pièce : au-delà du budget
+    # on écarte les excédentaires plutôt que de refuser tout le rapport.
+    MAX_CHARTS_BYTES = 4_000_000
+    # Cap du snapshot réellement persisté en base (graphiques déjà retirés).
+    MAX_SNAPSHOT_BYTES = 1_000_000
+
     website = forms.CharField(required=False, widget=forms.HiddenInput)
     consent = forms.BooleanField(required=True, error_messages={
         'required': "Vous devez accepter de recevoir le rapport.",
@@ -48,14 +55,42 @@ class SimulatorReportForm(forms.ModelForm):
         snapshot = self.cleaned_data.get('snapshot') or {}
         if not isinstance(snapshot, dict):
             raise forms.ValidationError("Format de données invalide.")
-        # Les graphiques (base64) peuvent faire 100-500KB chacun.
-        # Cap global à 2 Mo (≈ 4 graphiques) — anti-abus payload.
-        import json
-        if len(json.dumps(snapshot)) > 2_000_000:
-            raise forms.ValidationError("Données trop volumineuses.")
-        # Stockage DB : on retire les charts (lourds) avant persistance,
-        # mais on les garde pour la génération PDF via un attribut transient.
+        # Les graphiques sont extraits AVANT tout contrôle de taille : ils ne
+        # sont pas persistés en DB (transient, passés au service PDF) et ne
+        # doivent donc jamais faire échouer la demande de rapport. C'était la
+        # cause de l'erreur générique au téléchargement : 4 graphiques haute
+        # résolution suffisaient à dépasser le cap et à rejeter la requête.
         charts = snapshot.pop('_charts', None) or snapshot.pop('charts', None)
         if charts:
-            self._transient_charts = charts
+            self._transient_charts = self._trim_charts(charts)
+        # Ce qui reste (saisies + KPI, du texte) doit rester raisonnable.
+        import json
+        if len(json.dumps(snapshot)) > self.MAX_SNAPSHOT_BYTES:
+            raise forms.ValidationError(
+                "Les données du simulateur sont trop volumineuses. "
+                "Relancez le calcul puis réessayez."
+            )
         return snapshot
+
+    @classmethod
+    def _trim_charts(cls, charts: object) -> list:
+        """Tronque la liste de graphiques à ``MAX_CHARTS_BYTES``.
+
+        Conserve les graphiques dans l'ordre tant que le budget cumulé n'est
+        pas dépassé ; les suivants sont ignorés silencieusement. Le rapport
+        est ainsi toujours généré, éventuellement avec moins de visuels.
+        """
+        if not isinstance(charts, list):
+            return []
+        kept: list = []
+        total = 0
+        for chart in charts:
+            if not isinstance(chart, dict):
+                continue
+            data_url = chart.get('data_url')
+            weight = len(data_url) if isinstance(data_url, str) else 0
+            if total + weight > cls.MAX_CHARTS_BYTES:
+                continue
+            total += weight
+            kept.append(chart)
+        return kept

--- a/apps/simulateur/views.py
+++ b/apps/simulateur/views.py
@@ -363,8 +363,13 @@ class ReportSubmitView(View):
 
         form = SimulatorReportForm(payload)
         if not form.is_valid():
+            # `message` est indispensable : le front affiche `data.message`
+            # et retombait sinon sur un « Une erreur est survenue » opaque,
+            # sans jamais dire à l'utilisateur ce qu'il devait corriger.
             return JsonResponse(
-                {'ok': False, 'errors': form.errors.get_json_data()},
+                {'ok': False,
+                 'message': self._readable_error(form),
+                 'errors': form.errors.get_json_data()},
                 status=400,
             )
 
@@ -398,22 +403,15 @@ class ReportSubmitView(View):
         pdf_bytes: bytes | None = None
 
         # 1) En mode download, le PDF doit être généré de façon synchrone :
-        #    il est renvoyé dans la réponse (base64) pour téléchargement immédiat.
-        #    Une erreur de génération est donc bloquante.
+        #    il est renvoyé dans la réponse (base64) pour téléchargement
+        #    immédiat. Un échec est bloquant, d'où le repli sans graphiques.
         if delivery == 'download':
-            try:
-                pdf_bytes = SimulatorReportService.generate_pdf(
-                    report, charts=transient_charts,
-                )
-            except Exception as exc:  # noqa: BLE001
-                logger.error(
-                    "Échec génération PDF rapport simulateur #%s : %s",
-                    report.pk, exc, exc_info=True,
-                )
+            pdf_bytes = self._render_pdf_resilient(report, transient_charts)
+            if pdf_bytes is None:
                 return JsonResponse(
                     {'ok': False,
                      'message': "Nous n'avons pas pu générer le PDF. "
-                                'Réessayez ou contactez-nous.'},
+                                'Réessayez ou demandez-le par email.'},
                     status=500,
                 )
 
@@ -443,6 +441,55 @@ class ReportSubmitView(View):
                 '(pensez à regarder dans les spams).'
             )
         return JsonResponse(response)
+
+    @staticmethod
+    def _render_pdf_resilient(report: Any, charts: Any) -> bytes | None:
+        """Rend le PDF, en réessayant sans graphiques si le rendu échoue.
+
+        Les graphiques sont des images base64 produites par le navigateur :
+        c'est la partie la plus fragile du rendu. Plutôt que de refuser le
+        téléchargement, on retente sans eux — l'utilisateur repart avec son
+        rapport (texte, saisies, KPI, recommandations) au lieu d'une erreur.
+        Retourne ``None`` seulement si le rendu échoue même sans graphiques.
+        """
+        try:
+            return SimulatorReportService.generate_pdf(report, charts=charts)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "Échec génération PDF rapport simulateur #%s : %s",
+                report.pk, exc, exc_info=True,
+            )
+
+        if not charts:
+            return None
+
+        try:
+            pdf_bytes = SimulatorReportService.generate_pdf(report, charts=None)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "Échec génération PDF sans graphiques #%s : %s",
+                report.pk, exc, exc_info=True,
+            )
+            return None
+
+        logger.warning(
+            "PDF rapport simulateur #%s généré sans graphiques (repli).",
+            report.pk,
+        )
+        return pdf_bytes
+
+    @staticmethod
+    def _readable_error(form: SimulatorReportForm) -> str:
+        """Première erreur de validation, formulée pour l'utilisateur final."""
+        for field, errors in form.errors.items():
+            if not errors:
+                continue
+            text = str(errors[0])
+            if field in ('__all__', 'snapshot', 'website'):
+                return text
+            label = form.fields[field].label or field
+            return f"{label} : {text}"
+        return 'Une erreur est survenue. Réessayez.'
 
     @staticmethod
     def _dispatch_report_email(

--- a/templates/partials/simulator_report_modal.html
+++ b/templates/partials/simulator_report_modal.html
@@ -297,6 +297,10 @@ Snapshot des données : l'Alpine component du simulateur doit exposer
       toolSlug: '',
       toolName: '',
       endpoint: '',
+      // Budgets d'export des graphiques (longueur des data URL base64).
+      // Doivent rester <= SimulatorReportForm.MAX_CHARTS_BYTES côté serveur.
+      CHART_MAX_BYTES: 1200000,
+      CHART_BUDGET_BYTES: 3600000,
       form: {
         email: '', name: '', company: '',
         website: '',
@@ -695,11 +699,17 @@ Snapshot des données : l'Alpine component du simulateur doit exposer
         // Capture chaque instance Chart.js visible en PNG base64.
         // Exporte une variante "print-safe" pour conserver axes, graduations
         // et légendes en PDF, même quand la page est en thème sombre.
+        //
+        // Budget cumulé (CHART_BUDGET_BYTES) aligné sur le cap serveur : un
+        // graphique de plus ne doit jamais faire échouer tout le rapport, il
+        // est simplement écarté de l'export.
         const out = [];
+        let budget = this.CHART_BUDGET_BYTES;
         try {
           if (!window.Chart || !window.Chart.instances) return out;
           Object.values(window.Chart.instances).forEach(chart => {
             try {
+              if (out.length >= 4 || budget <= 0) return;
               const canvas = chart && chart.canvas;
               if (!canvas || !canvas.isConnected || canvas.offsetParent === null) return;
               // Titre : chercher un h3 parent proche
@@ -716,7 +726,8 @@ Snapshot des données : l'Alpine component du simulateur doit exposer
                 dataUrl = this.fallbackChartCapture(chart);
               }
 
-              if (dataUrl && dataUrl.length < 800000) { // garde-fou ~600KB binaire
+              if (dataUrl && dataUrl.length <= this.CHART_MAX_BYTES && dataUrl.length <= budget) {
+                budget -= dataUrl.length;
                 out.push({ ...meta, data_url: dataUrl });
               }
             } catch (e) { /* ignore single chart failure */ }
@@ -773,6 +784,30 @@ Snapshot des données : l'Alpine component du simulateur doit exposer
         } catch (e) {
           return false;
         }
+      },
+      describeError(res, data) {
+        // Le serveur renvoie toujours `message`. On garde `errors` en second
+        // recours (400 de validation), et un message explicite par statut :
+        // afficher "Une erreur est survenue" sans rien d'autre laissait
+        // l'utilisateur sans aucune piste sur ce qu'il devait corriger.
+        if (data && data.message) return data.message;
+        if (data && data.errors) {
+          const first = Object.values(data.errors)[0];
+          const entry = Array.isArray(first) ? first[0] : first;
+          const text = entry && (entry.message || entry);
+          if (typeof text === 'string' && text) return text;
+        }
+        const status = res && res.status;
+        if (status === 413) {
+          return "Le rapport est trop volumineux à envoyer. Relancez le calcul puis réessayez.";
+        }
+        if (status === 429) {
+          return 'Trop de demandes. Merci de réessayer dans quelques minutes.';
+        }
+        if (status >= 500) {
+          return "Le serveur n'a pas pu produire le rapport. Réessayez dans un instant ou demandez-le par email.";
+        }
+        return 'Une erreur est survenue. Réessayez.';
       },
       async submit() {
         this.error = '';
@@ -831,7 +866,7 @@ Snapshot des données : l'Alpine component du simulateur doit exposer
           });
           const data = await res.json().catch(() => ({}));
           if (!res.ok || data.ok === false) {
-            this.error = data.message || 'Une erreur est survenue. Réessayez.';
+            this.error = this.describeError(res, data);
           } else {
             if (data.pdf_base64) {
               const ok = this.triggerDownload(data.pdf_base64, data.filename);

--- a/tests/test_simulateur_report.py
+++ b/tests/test_simulateur_report.py
@@ -154,3 +154,148 @@ class TestSimulatorReportEndpoint:
         mock_send.assert_called_once()
         _, kwargs = mock_send.call_args
         assert kwargs['charts'] == chart_payload
+
+
+@pytest.mark.django_db
+class TestSimulatorReportRobustness:
+    """Garde-fous du téléchargement PDF (régression : erreur générique).
+
+    Des graphiques haute résolution suffisaient à faire dépasser le cap de
+    taille du snapshot : la requête était rejetée en 400 sans `message`, et
+    l'utilisateur ne voyait qu'un « Une erreur est survenue » opaque.
+    """
+
+    endpoint = '/simulateur/report/'
+
+    @staticmethod
+    def _chart(size_bytes: int, title: str = 'Graphique'):
+        return {
+            'title': title,
+            'x_label': 'Ventes',
+            'y_label': 'Euros (€)',
+            'series': ['Coûts'],
+            'data_url': 'data:image/png;base64,' + ('A' * size_bytes),
+        }
+
+    def _payload(self, charts, **overrides):
+        base = {
+            'email': 'dirigeant@acme.fr',
+            'name': 'Jean Dupont',
+            'company': 'Acme PME',
+            'tool_slug': 'point-mort',
+            'tool_name': 'Seuil de Rentabilité',
+            'delivery': 'download',
+            'consent': True,
+            'website': '',
+            'snapshot': {
+                'user_inputs': [{'label': 'Charges fixes', 'value': '4200'}],
+                'results': [{'label': 'Point mort', 'value': '18 400 €'}],
+                'charts': charts,
+            },
+        }
+        base.update(overrides)
+        return base
+
+    def _post(self, payload):
+        client = Client()
+        with patch('apps.simulateur.services.SimulatorReportService.send'):
+            return client.post(
+                self.endpoint,
+                data=json.dumps(payload),
+                content_type='application/json',
+            )
+
+    def test_heavy_charts_still_return_a_pdf(self):
+        """4 graphiques haute résolution (~2,4 Mo) : téléchargement OK."""
+        import base64
+
+        charts = [self._chart(600_000, f'Graphique {i}') for i in range(4)]
+        res = self._post(self._payload(charts))
+
+        assert res.status_code == 200, res.content
+        body = res.json()
+        assert body['ok'] is True
+        assert base64.b64decode(body['pdf_base64'])[:5] == b'%PDF-'
+
+    def test_charts_over_budget_are_trimmed_not_rejected(self):
+        """Au-delà du budget, les graphiques sont écartés — pas la demande."""
+        from apps.simulateur.forms import SimulatorReportForm
+
+        oversized = SimulatorReportForm.MAX_CHARTS_BYTES // 2 + 1
+        charts = [self._chart(oversized, f'Graphique {i}') for i in range(4)]
+
+        with patch(
+            'apps.simulateur.services.SimulatorReportService.generate_pdf',
+            return_value=b'%PDF-stub',
+        ) as mock_pdf, patch(
+            'apps.simulateur.services.SimulatorReportService.send'
+        ):
+            client = Client()
+            res = client.post(
+                self.endpoint,
+                data=json.dumps(self._payload(charts)),
+                content_type='application/json',
+            )
+
+        assert res.status_code == 200, res.content
+        forwarded = mock_pdf.call_args.kwargs['charts']
+        assert len(forwarded) == 1, 'budget must cap the forwarded charts'
+        assert forwarded[0]['title'] == 'Graphique 0'
+
+    def test_validation_error_carries_a_readable_message(self):
+        """Le front affiche `message` : il doit toujours être renseigné."""
+        payload = self._payload([], consent=False)
+        res = self._post(payload)
+
+        assert res.status_code == 400
+        body = res.json()
+        assert body['ok'] is False
+        message = body.get('message')
+        assert message, 'message is required by the front-end'
+        assert message != 'Une erreur est survenue. Réessayez.'
+        assert 'errors' in body
+
+    def test_pdf_render_falls_back_to_no_charts(self):
+        """Si le rendu échoue avec les graphiques, on retente sans eux."""
+        import base64
+
+        calls = []
+
+        def _generate(report, *, charts=None):
+            calls.append(charts)
+            if charts:
+                raise RuntimeError('WeasyPrint: image décodée invalide')
+            return b'%PDF-fallback'
+
+        with patch(
+            'apps.simulateur.services.SimulatorReportService.generate_pdf',
+            side_effect=_generate,
+        ), patch('apps.simulateur.services.SimulatorReportService.send'):
+            client = Client()
+            res = client.post(
+                self.endpoint,
+                data=json.dumps(self._payload([self._chart(1000)])),
+                content_type='application/json',
+            )
+
+        assert res.status_code == 200, res.content
+        assert base64.b64decode(res.json()['pdf_base64']) == b'%PDF-fallback'
+        assert len(calls) == 2 and calls[1] is None
+
+    def test_pdf_failure_without_charts_reports_a_message(self):
+        """Échec irrécupérable : message explicite, pas de fallback opaque."""
+        with patch(
+            'apps.simulateur.services.SimulatorReportService.generate_pdf',
+            side_effect=RuntimeError('boom'),
+        ), patch('apps.simulateur.services.SimulatorReportService.send'):
+            client = Client()
+            res = client.post(
+                self.endpoint,
+                data=json.dumps(self._payload([])),
+                content_type='application/json',
+            )
+
+        assert res.status_code == 500
+        body = res.json()
+        assert body['ok'] is False
+        assert 'PDF' in body['message']


### PR DESCRIPTION
## Symptôme

Dans le simulateur, cliquer sur **« Télécharger en PDF »**, renseigner ses informations puis valider affichait **« Une erreur est survenue »** — sans aucune indication, et sans PDF.

## Cause

`SimulatorReportForm.clean_snapshot` mesurait le snapshot **avant** d'en retirer les graphiques :

```python
if len(json.dumps(snapshot)) > 2_000_000:      # graphiques inclus
    raise forms.ValidationError("Données trop volumineuses.")
charts = snapshot.pop('_charts', None) or snapshot.pop('charts', None)
```

Or le front exporte les graphiques en haute résolution pour le PDF (`renderChartForPdf` rend à `max(1100, largeur × 2)`), avec un garde-fou de 800 Ko de base64 **par** graphique et jusqu'à 4 graphiques — soit jusqu'à 3,2 Mo, bien au-delà du cap serveur de 2 Mo. Dès que le simulateur affichait plusieurs graphiques, la validation échouait.

Deuxième problème, qui rendait le tout indéchiffrable : la réponse 400 ne contenait que `errors`, alors que le front n'affiche que `data.message` — d'où le texte générique.

Reproduit puis vérifié corrigé avec un payload réaliste (4 graphiques PNG à 900 px, 2,33 Mo) :

| Payload | Avant | Après |
|---|---|---|
| 4 graphiques, 1,41 Mo | 200 ✅ | 200 ✅ |
| 4 graphiques, 2,33 Mo | **400 « Données trop volumineuses »** | 200 ✅ |
| 6 graphiques, 5,53 Mo | **400** | 200 ✅ (graphiques tronqués au budget) |

## Correctifs

**`apps/simulateur/forms.py`**
- les graphiques sont extraits du snapshot **avant** tout contrôle de taille : ils sont transients (jamais persistés en DB) et ne doivent donc pas pouvoir faire échouer la demande ;
- ils sont tronqués à un budget global (`MAX_CHARTS_BYTES = 4 Mo`) au lieu de provoquer un rejet — le rapport est toujours produit, éventuellement avec moins de visuels ;
- le cap restant (`MAX_SNAPSHOT_BYTES = 1 Mo`) ne porte plus que sur le snapshot réellement stocké (saisies + KPI, du texte).

**`apps/simulateur/views.py`**
- la réponse 400 embarque toujours un `message` lisible, dérivé de la première erreur de validation (`_readable_error`) ;
- repli `_render_pdf_resilient` : si le rendu WeasyPrint échoue avec les graphiques (partie la plus fragile, images produites par le navigateur), on retente sans eux plutôt que de refuser le téléchargement.

**`templates/partials/simulator_report_modal.html`**
- budget cumulé à la capture des graphiques (`CHART_BUDGET_BYTES`), aligné sur le cap serveur : un graphique de trop est écarté de l'export au lieu de faire échouer le rapport ;
- `describeError()` : message explicite selon le statut (413 / 429 / 5xx) et lecture de `errors` en second recours, au lieu du « Une erreur est survenue » systématique.

## Tests

5 tests de régression ajoutés dans `tests/test_simulateur_report.py` (`TestSimulatorReportRobustness`) : payload lourd, troncature au budget, présence du `message` de validation, repli sans graphiques, et échec irrécupérable.

- 4 de ces 5 tests échouent sur le code d'avant le correctif.
- Suite complète : **776 tests passent**.
- Logique front vérifiée hors navigateur (`describeError` + budget de `captureCharts`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XD9SLYey3ykz78tU1Hwez8


---
_Generated by [Claude Code](https://claude.ai/code/session_01XD9SLYey3ykz78tU1Hwez8)_

## Summary by Sourcery

Make simulator PDF downloads resilient to oversized or invalid chart data while providing actionable errors to users.

Bug Fixes:
- Prevent high-resolution chart data from causing simulator PDF requests to be rejected.
- Fall back to generating the PDF without charts when chart rendering fails.
- Return readable validation and server error messages instead of a generic download failure.

Enhancements:
- Apply cumulative chart-size limits and retain only the snapshot data that is persisted.
- Improve client-side chart export and error reporting for common HTTP failure statuses.

Tests:
- Add regression coverage for oversized charts, chart trimming, readable validation errors, PDF fallback rendering, and unrecoverable PDF failures.