### PR TITLE
fix(simulateur): slug d'outil corrompu par escapejs dans le modal

### DIFF
--- a/templates/partials/simulator_report_modal.html
+++ b/templates/partials/simulator_report_modal.html
@@ -162,9 +162,12 @@ Snapshot des données : l'Alpine component du simulateur doit exposer
     }
 </style>
 
+{# Attributs HTML : l'auto-échappement Django suffit. `escapejs` (destiné aux
+   littéraux JS) transformerait « point-mort » en « point\u002Dmort » — le
+   tiret est échappé — et le slug envoyé au serveur serait invalide. #}
 <div x-data="simulatorReportModal"
-     data-tool-slug="{{ tool_slug|escapejs }}"
-     data-tool-name="{{ tool_name|escapejs }}"
+     data-tool-slug="{{ tool_slug }}"
+     data-tool-name="{{ tool_name }}"
      data-endpoint="{% url 'simulateur:report_submit' %}"
      @open-report-modal.window="open($event.detail)">
 

--- a/tests/test_simulateur_report.py
+++ b/tests/test_simulateur_report.py
@@ -299,3 +299,80 @@ class TestSimulatorReportRobustness:
         body = res.json()
         assert body['ok'] is False
         assert 'PDF' in body['message']
+
+
+@pytest.mark.django_db
+class TestSimulatorReportModalMarkup:
+    """Le modal doit exposer un `tool_slug` que le serveur accepte.
+
+    Régression : les attributs `data-tool-*` passaient par `escapejs`, filtre
+    destiné aux littéraux JavaScript, qui échappe le tiret (`-` → `\\u002D`).
+    Dans un attribut HTML, `dataset.toolSlug` relisait « point\\u002Dmort » :
+    le SlugField rejetait la valeur et aucun rapport n'était généré pour les
+    22 outils (sur 30) dont le slug contient un tiret.
+    """
+
+    @staticmethod
+    def _tool_url_names():
+        from apps.simulateur import urls as simulateur_urls
+
+        skipped = {'hub', 'report_submit', 'conformite-facture-check'}
+        return [
+            pattern.name
+            for pattern in simulateur_urls.urlpatterns
+            if pattern.name and pattern.name not in skipped
+        ]
+
+    @staticmethod
+    def _data_attr(html: str, attr: str) -> str:
+        import re
+
+        match = re.search(rf'{attr}="([^"]*)"', html)
+        assert match, f'{attr} absent du modal'
+        return match.group(1)
+
+    def test_every_tool_page_exposes_a_valid_slug(self):
+        import html as html_lib
+
+        from apps.simulateur.forms import SimulatorReportForm
+
+        client = Client()
+        checked = 0
+        for url_name in self._tool_url_names():
+            url = reverse(f'simulateur:{url_name}')
+            res = client.get(url)
+            if res.status_code != 200:
+                continue
+            body = res.content.decode()
+            if 'data-tool-slug' not in body:
+                continue
+            checked += 1
+
+            slug = html_lib.unescape(self._data_attr(body, 'data-tool-slug'))
+            assert '\\u' not in slug, f'{url_name}: slug échappé « {slug} »'
+
+            # Le slug rendu doit passer la validation serveur telle quelle.
+            form = SimulatorReportForm({
+                'email': 'dirigeant@acme.fr',
+                'tool_slug': slug,
+                'tool_name': 'Outil',
+                'snapshot': {},
+                'consent': True,
+                'website': '',
+            })
+            assert form.is_valid(), f'{url_name}: {form.errors.as_json()}'
+
+        assert checked >= 20, f'seulement {checked} pages outils vérifiées'
+
+    def test_tool_name_is_not_js_escaped(self):
+        """Les apostrophes ne doivent pas fuir en « \\u0027 » dans le PDF."""
+        import html as html_lib
+
+        client = Client()
+        res = client.get(reverse('simulateur:cac'))
+        assert res.status_code == 200
+
+        name = html_lib.unescape(
+            self._data_attr(res.content.decode(), 'data-tool-name')
+        )
+        assert name == "Coût d'Acquisition", name


### PR DESCRIPTION
Suite de #21. Le message d'erreur lisible introduit par cette PR a immédiatement révélé la cause réelle, jusque-là masquée par le « Une erreur est survenue » générique :

> **Outil (slug) : Ce champ ne doit contenir que des lettres, des nombres, des tirets bas (_) et des traits d'union.**

## Cause

Les attributs `data-*` du modal passaient par `escapejs` :

```django
data-tool-slug="{{ tool_slug|escapejs }}"
data-tool-name="{{ tool_name|escapejs }}"
```

`escapejs` est destiné aux **littéraux JavaScript**, pas aux attributs HTML. Il échappe le tiret et l'apostrophe :

```python
>>> escapejs('point-mort')
'point-mort'
>>> escapejs("Coût d'Acquisition")
'Coût d'Acquisition'
```

`dataset.toolSlug` relisait donc la chaîne littérale `point-mort`, que le `SlugField` rejette.

**22 des 30 outils** ont un tiret dans leur slug (`point-mort`, `vallee-mort`, `mix-produits`, `prix-psychologique`, `cout-inaction`…) : pour eux, le rapport était impossible à obtenir, **en téléchargement comme par email**. En mode email l'échec était silencieux — la réponse HTTP restait un succès apparent côté formulaire.

Le nom d'outil était touché aussi : « Coût d'Acquisition » arrivait en `Coût d'Acquisition` et se serait affiché tel quel dans le PDF.

## Correctif

Dans un attribut HTML, l'auto-échappement Django suffit et convient — il échappe `"`, `'`, `<`, `>`, `&` sous une forme que le navigateur redécode correctement. Les deux `|escapejs` sont retirés, avec un commentaire expliquant pourquoi.

Les autres usages d'`escapejs` du projet (schema.org JSON-LD, `prospects_json`) sont, eux, corrects : ils alimentent bien des littéraux JSON/JS. Vérifié, aucun autre attribut HTML concerné.

## Tests

`TestSimulatorReportModalMarkup` parcourt **les 30 pages outils** et vérifie que le slug rendu passe la validation `SimulatorReportForm` telle quelle, plus un test sur le nom d'outil.

- Les 2 tests échouent sur le code d'avant le correctif (`conformite-facture`).
- Suite complète : **778 tests passent**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XD9SLYey3ykz78tU1Hwez8


---
_Generated by [Claude Code](https://claude.ai/code/session_01XD9SLYey3ykz78tU1Hwez8)_

## Summary by Sourcery

Fix simulator report metadata encoding so downloads and emailed reports work reliably for all tools.

Bug Fixes:
- Correct the simulator report modal's tool slug and name values so reports can be generated for tools containing hyphens or apostrophes in their metadata.

Tests:
- Add regression coverage across the simulator tool pages to ensure rendered slugs pass server validation and tool names remain intact.