### PR TITLE
feat(deploy): socle de migration Render vers OVH + Coolify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,10 @@ FROM python:3.12-slim-bookworm
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     DJANGO_SETTINGS_MODULE=config.settings.production \
-    PORT=8000
+    PORT=8000 \
+    GUNICORN_WORKERS=2 \
+    GUNICORN_THREADS=4 \
+    GUNICORN_TIMEOUT=120
 
 WORKDIR /app
 
@@ -44,6 +47,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-liberation \
     fonts-dejavu-core \
     libpq5 \
+    # pg_dump : sauvegarde de la base vers le stockage objet, PostgreSQL
+    # n'étant plus managé par la plateforme (voir core/management/commands/
+    # backup_database.py).
+    postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy installed Python packages from builder
@@ -77,4 +84,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
 # les workers. Garantit que SECRET_KEY, settings et connexions DB sont
 # identiques dans tous les workers (élimine le risque de clé aléatoire
 # différente par worker si DJANGO_SECRET_KEY est absent/faible).
-CMD ["sh", "-c", "DJANGO_SETTINGS_MODULE=config.settings.production gunicorn config.wsgi:application --preload --bind 0.0.0.0:${PORT} --workers 2 --threads 4 --timeout 120"]
+# Le dimensionnement vient de l'environnement : 2 workers suffisaient sur le
+# plan Render (512 Mo), un VPS 4 vCPU / 12 Go en supporte bien davantage sans
+# changer d'image.
+CMD ["sh", "-c", "DJANGO_SETTINGS_MODULE=config.settings.production gunicorn config.wsgi:application --preload --bind 0.0.0.0:${PORT} --workers ${GUNICORN_WORKERS} --threads ${GUNICORN_THREADS} --timeout ${GUNICORN_TIMEOUT}"]

--- a/build.sh
+++ b/build.sh
@@ -69,9 +69,14 @@ EOFTOTP
 #    provisoire interne assure un badge en attendant, et le prochain déploiement
 #    (ou le cron hebdo) récupère le grade officiel.
 echo ""
-echo "📊 Audit portfolio (remplissage initial des projets sans mesure)..."
-python manage.py audit_portfolio_projects --only-missing || \
-    echo "⚠️  Audit portfolio ignoré (non bloquant) — sera relancé par le cron."
+if [ "${SKIP_DEPLOY_AUDIT:-0}" = "1" ]; then
+    echo "📊 Audit portfolio ignoré (SKIP_DEPLOY_AUDIT=1) — pris en charge"
+    echo "   par la tâche planifiée hebdomadaire."
+else
+    echo "📊 Audit portfolio (remplissage initial des projets sans mesure)..."
+    python manage.py audit_portfolio_projects --only-missing || \
+        echo "⚠️  Audit portfolio ignoré (non bloquant) — sera relancé par le cron."
+fi
 
 echo ""
 echo "=========================================="

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -19,22 +19,50 @@ DEBUG = False
 # HOSTS & SECURITY
 # ==============================================================================
 # 🛡️ ZERO TRUST: Strict domain whitelist - NO wildcards
-ALLOWED_HOSTS = [
-    'trait-d-union.onrender.com',  # Render exact subdomain
+#
+# Les domaines de base sont ceux du site ; l'hébergeur ajoute le sien via
+# DJANGO_ALLOWED_HOSTS (liste séparée par des virgules). Cela évite de coder
+# en dur un domaine de plateforme — c'est ce qui rendait ces settings
+# dépendants de Render.
+_BASE_ALLOWED_HOSTS = [
     'traitdunion.it',
     'www.traitdunion.it',
 ]
 
+
+def _env_list(name: str) -> list[str]:
+    """Liste depuis une variable d'env séparée par des virgules."""
+    raw = os.environ.get(name, '')
+    return [item.strip() for item in raw.split(',') if item.strip()]
+
+
+ALLOWED_HOSTS = list(dict.fromkeys(
+    _BASE_ALLOWED_HOSTS + _env_list('DJANGO_ALLOWED_HOSTS')
+))
+
 # CSRF trusted origins - DOIT inclure le scheme https://
-CSRF_TRUSTED_ORIGINS = [
-    'https://trait-d-union.onrender.com',
-    'https://traitdunion.it',
-    'https://www.traitdunion.it',
-]
+# Dérivé des hôtes autorisés : déclarer un domaine à deux endroits est une
+# source d'erreur classique au déploiement (CSRF qui échoue en silence sur le
+# domaine de la plateforme). CSRF_TRUSTED_ORIGINS reste disponible pour les
+# cas particuliers (port non standard, autre schéma).
+def _as_origin(value: str) -> str:
+    if '://' in value:
+        return value
+    # '.exemple.fr' (sous-domaines) → 'https://*.exemple.fr'
+    if value.startswith('.'):
+        return f'https://*{value}'
+    return f'https://{value}'
+
+
+CSRF_TRUSTED_ORIGINS = list(dict.fromkeys(
+    [_as_origin(host) for host in ALLOWED_HOSTS if host != '*']
+    + [_as_origin(origin) for origin in _env_list('CSRF_TRUSTED_ORIGINS')]
+))
 
 # Sécurité HTTPS
-# SSL redirect is handled by Render's load balancer — do NOT duplicate it here
-# or it causes ERR_TOO_MANY_REDIRECTS (Render terminates SSL then forwards HTTP)
+# Le reverse proxy (load balancer Render, Traefik chez Coolify) termine déjà
+# le TLS et redirige HTTP→HTTPS. Dupliquer la redirection ici provoquerait un
+# ERR_TOO_MANY_REDIRECTS, le proxy transmettant ensuite la requête en clair.
 SECURE_SSL_REDIRECT = False
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 SESSION_COOKIE_SECURE = True
@@ -124,25 +152,87 @@ _HASHED_FILE_RE = re.compile(r'\.[a-f0-9]{8,32}\.')
 WHITENOISE_IMMUTABLE_FILE_TEST = lambda path, url: bool(_HASHED_FILE_RE.search(url))
 
 # ==============================================================================
-# MEDIA FILES (Cloudinary - recommandé pour simplicité)
+# MEDIA FILES — OVH Object Storage (S3) > Cloudinary > disque local
 # ==============================================================================
+# L'ordre est volontaire : il permet de basculer de Cloudinary vers OVH en
+# ajoutant simplement les variables S3_*, sans toucher au code ni redéployer
+# deux fois. Tant qu'elles sont absentes, Cloudinary continue de servir.
+
+import sys
+
+# Vérifier si on est en train de builder (collectstatic)
+IS_BUILDING = 'collectstatic' in sys.argv
+
+_STATIC_STORAGE = {'BACKEND': 'core.storage.ResilientManifestStaticFilesStorage'}
+
+
+def _log_settings():
+    import logging as _log
+    return _log.getLogger('config.settings')
+
+
+# ── OVH Object Storage (S3-compatible) ───────────────────────────
+AWS_STORAGE_BUCKET_NAME = os.environ.get('S3_BUCKET_NAME')
+AWS_S3_ENDPOINT_URL = os.environ.get('S3_ENDPOINT_URL')
+AWS_ACCESS_KEY_ID = os.environ.get('S3_ACCESS_KEY_ID')
+AWS_SECRET_ACCESS_KEY = os.environ.get('S3_SECRET_ACCESS_KEY')
+AWS_S3_REGION_NAME = os.environ.get('S3_REGION_NAME', 'gra')
+
+# Domaine public servant les médias : conteneur public OVH, ou CDN devant.
+AWS_S3_CUSTOM_DOMAIN = os.environ.get('S3_CUSTOM_DOMAIN') or None
+
+_S3_CONFIGURED = bool(
+    AWS_STORAGE_BUCKET_NAME
+    and AWS_S3_ENDPOINT_URL
+    and AWS_ACCESS_KEY_ID
+    and AWS_SECRET_ACCESS_KEY
+)
+
+# ── Cloudinary (historique) ──────────────────────────────────────
 CLOUDINARY_CLOUD_NAME = os.environ.get('CLOUDINARY_CLOUD_NAME')
 CLOUDINARY_API_KEY = os.environ.get('CLOUDINARY_API_KEY')
 CLOUDINARY_API_SECRET = os.environ.get('CLOUDINARY_API_SECRET')
 CLOUDINARY_URL = os.environ.get('CLOUDINARY_URL')
 
-# Vérifier si on est en train de builder (collectstatic)
-import sys
-IS_BUILDING = 'collectstatic' in sys.argv
+_CLOUDINARY_CONFIGURED = bool(
+    CLOUDINARY_URL or (CLOUDINARY_CLOUD_NAME and CLOUDINARY_API_KEY)
+)
 
-if CLOUDINARY_URL or (CLOUDINARY_CLOUD_NAME and CLOUDINARY_API_KEY):
+if _S3_CONFIGURED:
     if not IS_BUILDING:
-        import logging as _log
-        _log.getLogger('config.settings').info('Cloudinary configuration found')
-    
-    # Configuration Cloudinary
+        _log_settings().info(
+            'Media storage: OVH Object Storage (bucket=%s)',
+            AWS_STORAGE_BUCKET_NAME,
+        )
+
+    # Les objets sont servis publiquement en lecture : pas de signature dans
+    # l'URL, donc des liens stables et cachables par le navigateur/CDN.
+    AWS_QUERYSTRING_AUTH = False
+    AWS_DEFAULT_ACL = None  # OVH refuse les ACL par objet ; le conteneur porte la policy.
+    AWS_S3_FILE_OVERWRITE = False
+    AWS_S3_SIGNATURE_VERSION = 's3v4'
+    AWS_S3_ADDRESSING_STYLE = 'virtual'
+    AWS_S3_OBJECT_PARAMETERS = {
+        'CacheControl': 'public, max-age=31536000, immutable',
+    }
+
+    STORAGES = {
+        'default': {'BACKEND': 'storages.backends.s3.S3Storage'},
+        'staticfiles': _STATIC_STORAGE,
+    }
+
+    if AWS_S3_CUSTOM_DOMAIN:
+        MEDIA_URL = f'https://{AWS_S3_CUSTOM_DOMAIN}/'
+    else:
+        _endpoint_host = AWS_S3_ENDPOINT_URL.split('://', 1)[-1].rstrip('/')
+        MEDIA_URL = f'https://{AWS_STORAGE_BUCKET_NAME}.{_endpoint_host}/'
+
+elif _CLOUDINARY_CONFIGURED:
+    if not IS_BUILDING:
+        _log_settings().info('Media storage: Cloudinary')
+
     INSTALLED_APPS += ['cloudinary', 'cloudinary_storage']
-    
+
     if CLOUDINARY_CLOUD_NAME and CLOUDINARY_API_KEY:
         CLOUDINARY_STORAGE = {
             'CLOUD_NAME': CLOUDINARY_CLOUD_NAME,
@@ -152,44 +242,30 @@ if CLOUDINARY_URL or (CLOUDINARY_CLOUD_NAME and CLOUDINARY_API_KEY):
     else:
         # Si CLOUDINARY_URL est défini, on laisse la lib le gérer
         CLOUDINARY_STORAGE = {}
-    
-    # Configuration moderne Django 5+
-    # ⚡ PERFORMANCE: CompressedManifestStaticFilesStorage for hash-based filenames
-    # This enables immutable caching with automatic cache busting
+
     STORAGES = {
-        "default": {
-            "BACKEND": "cloudinary_storage.storage.MediaCloudinaryStorage",
-        },
-        "staticfiles": {
-            "BACKEND": "core.storage.ResilientManifestStaticFilesStorage",
-        },
+        'default': {'BACKEND': 'cloudinary_storage.storage.MediaCloudinaryStorage'},
+        'staticfiles': _STATIC_STORAGE,
     }
-    
-    # Fallback pour compatibilité
-    DEFAULT_FILE_STORAGE = 'cloudinary_storage.storage.MediaCloudinaryStorage'
-    
+
     # IMPORTANT : Ne pas surcharger MEDIA_URL avec l'URL Cloudinary brute.
-    # La librairie cloudinary_storage génère elle-même les URLs complètes (incluant /image/upload/...).
-    # En laissant /media/, on évite de casser les liens.
+    # La librairie génère elle-même les URLs complètes (incluant /image/upload/).
     MEDIA_URL = '/media/'
+
 else:
-    # Mode Build ou Config manquante
     if IS_BUILDING:
-        import logging as _log
-        _log.getLogger('config.settings').info('Build mode detected: Skipping Cloudinary checks')
+        _log_settings().info('Build mode detected: skipping media storage checks')
     else:
-        import logging as _log
-        _log.getLogger('config.settings').warning('CLOUDINARY ENV VARS MISSING! External media storage will NOT work.')
-    
-    # Configuration minimale pour le build
-    # ⚡ PERFORMANCE: CompressedManifestStaticFilesStorage for hash-based filenames
+        _log_settings().warning(
+            'AUCUN STOCKAGE MEDIA EXTERNE CONFIGURE ! '
+            'Definir S3_* (OVH Object Storage) ou CLOUDINARY_*. '
+            'Les fichiers uploades resteront sur le disque du conteneur '
+            'et seront perdus au redeploiement.'
+        )
+
     STORAGES = {
-        "default": {
-            "BACKEND": "django.core.files.storage.FileSystemStorage",
-        },
-        "staticfiles": {
-            "BACKEND": "core.storage.ResilientManifestStaticFilesStorage",
-        },
+        'default': {'BACKEND': 'django.core.files.storage.FileSystemStorage'},
+        'staticfiles': _STATIC_STORAGE,
     }
 
 # ==============================================================================
@@ -385,7 +461,9 @@ if SENTRY_DSN:
         
         # Environnement
         environment='production',
-        release=os.environ.get('RENDER_GIT_COMMIT', 'unknown'),
+        release=(os.environ.get('GIT_COMMIT_SHA')
+                 or os.environ.get('SOURCE_COMMIT')
+                 or os.environ.get('RENDER_GIT_COMMIT', 'unknown')),
         
         # Options
         send_default_pii=False,  # RGPD: pas de données personnelles
@@ -477,6 +555,18 @@ CONTENT_SECURITY_POLICY = {
     },
     "EXCLUDE_URL_PREFIXES": ["/tus-gestion-secure/"],
 }
+
+# Le stockage médias est choisi à l'exécution (OVH Object Storage ou
+# Cloudinary) : la CSP doit suivre, sinon les images et PDF servis depuis le
+# nouveau domaine sont bloqués par le navigateur après la bascule.
+_MEDIA_CSP_ORIGIN = ''
+if _S3_CONFIGURED:
+    _MEDIA_CSP_ORIGIN = MEDIA_URL.rstrip('/')
+if _MEDIA_CSP_ORIGIN:
+    for _directive in ('img-src', 'media-src'):
+        _sources = CONTENT_SECURITY_POLICY['DIRECTIVES'][_directive]
+        if _MEDIA_CSP_ORIGIN not in _sources:
+            _sources.append(_MEDIA_CSP_ORIGIN)
 
 # 🔻 Bascule build Alpine CSP : quand ALPINE_CSP_BUILD=1, le build @alpinejs/csp
 # est servi (cf. base.html) et 'unsafe-eval' n'est plus nécessaire → on le retire.

--- a/core/management/commands/backup_database.py
+++ b/core/management/commands/backup_database.py
@@ -1,0 +1,239 @@
+"""Sauvegarde la base PostgreSQL vers un stockage objet S3 (OVH).
+
+Sur Render, la base managée était sauvegardée quotidiennement par la
+plateforme. En auto-hébergeant PostgreSQL dans un conteneur sur le VPS, cette
+garantie disparaît : cette commande la remplace.
+
+Le dump est produit au format ``custom`` de pg_dump (compressé, restaurable
+sélectivement via ``pg_restore``), chiffré si ``BACKUP_ENCRYPTION_KEY`` est
+défini, puis poussé vers le stockage objet. Les sauvegardes plus anciennes que
+la rétention sont supprimées.
+
+Planifié via une tâche planifiée Coolify (voir deploy/README.md) :
+
+    python manage.py backup_database
+
+Restauration : voir deploy/README.md, section « Restaurer une sauvegarde ».
+"""
+from __future__ import annotations
+
+import datetime as dt
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+DEFAULT_PREFIX = 'postgres/'
+DEFAULT_RETENTION_DAYS = 30
+
+# nom : traitdunion-2026-08-19T14-30-00Z.dump[.enc]
+_BACKUP_RE = re.compile(
+    r'^(?P<db>.+)-(?P<stamp>\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z)\.dump(\.enc)?$'
+)
+
+
+class Command(BaseCommand):
+    help = "Sauvegarde PostgreSQL vers le stockage objet S3 (OVH)."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            '--bucket',
+            default=os.environ.get('BACKUP_S3_BUCKET') or '',
+            help="Bucket de destination (défaut : BACKUP_S3_BUCKET, sinon S3_BUCKET_NAME).",
+        )
+        parser.add_argument(
+            '--prefix',
+            default=os.environ.get('BACKUP_S3_PREFIX', DEFAULT_PREFIX),
+            help=f"Préfixe des objets (défaut « {DEFAULT_PREFIX} »).",
+        )
+        parser.add_argument(
+            '--retention-days', type=int,
+            default=int(os.environ.get('BACKUP_RETENTION_DAYS', DEFAULT_RETENTION_DAYS)),
+            help=f"Supprime les sauvegardes plus anciennes (défaut {DEFAULT_RETENTION_DAYS} j).",
+        )
+        parser.add_argument(
+            '--keep-local', action='store_true',
+            help="Conserve le fichier local (débogage).",
+        )
+        parser.add_argument(
+            '--dry-run', action='store_true',
+            help="Produit le dump sans l'envoyer ni purger quoi que ce soit.",
+        )
+
+    # ── Entrée ───────────────────────────────────────────────────
+    def handle(self, *args, **options) -> None:
+        bucket = options['bucket'] or getattr(settings, 'AWS_STORAGE_BUCKET_NAME', '')
+        if not bucket and not options['dry_run']:
+            raise CommandError(
+                "Aucun bucket de destination : définir BACKUP_S3_BUCKET "
+                "(ou S3_BUCKET_NAME), ou utiliser --dry-run."
+            )
+
+        db = settings.DATABASES['default']
+        stamp = dt.datetime.now(dt.timezone.utc).strftime('%Y-%m-%dT%H-%M-%SZ')
+        name = f"{db.get('NAME') or 'database'}-{stamp}.dump"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / name
+            self._pg_dump(db, path)
+
+            key_material = os.environ.get('BACKUP_ENCRYPTION_KEY')
+            if key_material:
+                path = self._encrypt(path, key_material)
+            else:
+                self.stdout.write(self.style.WARNING(
+                    "BACKUP_ENCRYPTION_KEY absent — sauvegarde envoyée en clair. "
+                    "La base contient des données personnelles (leads, devis, "
+                    "factures) : définir cette variable est vivement conseillé."
+                ))
+
+            size_mb = path.stat().st_size / 1_048_576
+            self.stdout.write(f"Dump prêt : {path.name} ({size_mb:.1f} Mo)")
+
+            if options['dry_run']:
+                self.stdout.write(self.style.WARNING('--dry-run : aucun envoi.'))
+                if options['keep_local']:
+                    self._keep_local(path)
+                return
+
+            self._upload(path, bucket, options['prefix'])
+            if options['keep_local']:
+                self._keep_local(path)
+
+        removed = self._prune(bucket, options['prefix'], options['retention_days'])
+        self.stdout.write(self.style.SUCCESS(
+            f"Sauvegarde terminée ({removed} ancienne(s) supprimée(s))."
+        ))
+
+    # ── Étapes ───────────────────────────────────────────────────
+    def _pg_dump(self, db: dict, path: Path) -> None:
+        """Produit le dump. Le mot de passe passe par l'environnement.
+
+        Le format ``custom`` (-Fc) est compressé et permet une restauration
+        sélective, table par table, avec pg_restore.
+        """
+        engine = db.get('ENGINE', '')
+        if 'postgresql' not in engine:
+            raise CommandError(
+                f"Base non PostgreSQL ({engine}) : sauvegarde non supportée."
+            )
+
+        cmd = ['pg_dump', '--format=custom', '--no-owner', '--no-privileges',
+               '--file', str(path)]
+        env = os.environ.copy()
+
+        # Django expose l'URL éclatée ; on reconstruit les options pg_dump.
+        if db.get('HOST'):
+            cmd += ['--host', db['HOST']]
+        if db.get('PORT'):
+            cmd += ['--port', str(db['PORT'])]
+        if db.get('USER'):
+            cmd += ['--username', db['USER']]
+        if db.get('PASSWORD'):
+            env['PGPASSWORD'] = db['PASSWORD']
+        cmd.append(db['NAME'])
+
+        self.stdout.write(f"pg_dump → {db.get('HOST') or 'local'}/{db['NAME']}…")
+        try:
+            proc = subprocess.run(
+                cmd, env=env, capture_output=True, text=True, timeout=3600,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise CommandError(
+                "pg_dump introuvable — le paquet postgresql-client doit être "
+                "installé dans l'image (voir Dockerfile)."
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise CommandError('pg_dump : délai dépassé (1 h).') from exc
+
+        if proc.returncode != 0:
+            raise CommandError(f"pg_dump a échoué : {proc.stderr.strip()[:500]}")
+
+    def _encrypt(self, path: Path, key_material: str) -> Path:
+        """Chiffre le dump en AES-256 via openssl (dérivation PBKDF2)."""
+        target = path.with_suffix(path.suffix + '.enc')
+        env = os.environ.copy()
+        env['BACKUP_PASSPHRASE'] = key_material
+        try:
+            proc = subprocess.run(
+                ['openssl', 'enc', '-aes-256-cbc', '-pbkdf2', '-iter', '200000',
+                 '-salt', '-in', str(path), '-out', str(target),
+                 '-pass', 'env:BACKUP_PASSPHRASE'],
+                env=env, capture_output=True, text=True, timeout=1800,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise CommandError("openssl introuvable dans l'image.") from exc
+
+        if proc.returncode != 0:
+            raise CommandError(f"Chiffrement échoué : {proc.stderr.strip()[:500]}")
+
+        path.unlink(missing_ok=True)
+        return target
+
+    def _upload(self, path: Path, bucket: str, prefix: str) -> None:
+        client = self._s3_client()
+        key = f"{prefix.rstrip('/')}/{path.name}" if prefix else path.name
+        self.stdout.write(f"Envoi → s3://{bucket}/{key}…")
+        client.upload_file(str(path), bucket, key)
+
+    def _prune(self, bucket: str, prefix: str, retention_days: int) -> int:
+        """Supprime les sauvegardes dont l'horodatage dépasse la rétention.
+
+        On se fie à l'horodatage du nom plutôt qu'à ``LastModified`` : ce
+        dernier changerait si un objet était recopié, ce qui prolongerait
+        silencieusement la rétention.
+        """
+        if retention_days <= 0:
+            return 0
+
+        client = self._s3_client()
+        cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=retention_days)
+        removed = 0
+
+        paginator = client.get_paginator('list_objects_v2')
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get('Contents', []):
+                name = obj['Key'].rsplit('/', 1)[-1]
+                match = _BACKUP_RE.match(name)
+                if not match:
+                    continue
+                created = dt.datetime.strptime(
+                    match.group('stamp'), '%Y-%m-%dT%H-%M-%SZ'
+                ).replace(tzinfo=dt.timezone.utc)
+                if created < cutoff:
+                    client.delete_object(Bucket=bucket, Key=obj['Key'])
+                    removed += 1
+                    self.stdout.write(f"  purge : {obj['Key']}")
+        return removed
+
+    # ── Utilitaires ──────────────────────────────────────────────
+    def _s3_client(self):
+        try:
+            import boto3
+        except ImportError as exc:  # pragma: no cover - dépendance déclarée
+            raise CommandError('boto3 est requis pour la sauvegarde.') from exc
+
+        endpoint = os.environ.get('BACKUP_S3_ENDPOINT_URL') or getattr(
+            settings, 'AWS_S3_ENDPOINT_URL', None
+        )
+        return boto3.client(
+            's3',
+            endpoint_url=endpoint,
+            aws_access_key_id=(os.environ.get('BACKUP_S3_ACCESS_KEY_ID')
+                               or getattr(settings, 'AWS_ACCESS_KEY_ID', None)),
+            aws_secret_access_key=(os.environ.get('BACKUP_S3_SECRET_ACCESS_KEY')
+                                   or getattr(settings, 'AWS_SECRET_ACCESS_KEY', None)),
+            region_name=(os.environ.get('BACKUP_S3_REGION_NAME')
+                         or getattr(settings, 'AWS_S3_REGION_NAME', 'gra')),
+        )
+
+    def _keep_local(self, path: Path) -> None:
+        target = Path(settings.BASE_DIR) / path.name
+        target.write_bytes(path.read_bytes())
+        self.stdout.write(f"Copie locale conservée : {target}")

--- a/core/management/commands/migrate_media_to_s3.py
+++ b/core/management/commands/migrate_media_to_s3.py
@@ -1,0 +1,251 @@
+"""Recopie les médias de Cloudinary vers le stockage objet OVH (S3).
+
+Parcourt tous les ``FileField`` / ``ImageField`` de tous les modèles et
+transfère chaque fichier référencé. Le **nom stocké en base n'est jamais
+modifié** : c'est ce qui rend la bascule sans risque et réversible. Une fois
+les fichiers copiés, il suffit de définir les variables ``S3_*`` pour que
+Django serve les mêmes chemins depuis OVH — et de retirer ces variables pour
+revenir à Cloudinary si besoin.
+
+À lancer **avant** la bascule, pendant que Cloudinary est encore actif :
+
+    python manage.py migrate_media_to_s3 --dry-run   # inventaire
+    python manage.py migrate_media_to_s3            # transfert
+
+La commande est idempotente : un fichier déjà présent à destination est
+ignoré, ce qui permet de la relancer autant de fois que nécessaire (reprise
+après coupure réseau, ajout de nouveaux médias entre deux passes).
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+
+from django.apps import apps
+from django.core.files.base import ContentFile
+from django.core.management.base import BaseCommand, CommandError
+from django.db import models
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Report:
+    copied: int = 0
+    skipped: int = 0
+    missing: int = 0
+    failed: int = 0
+    errors: list[str] = dataclass_field(default_factory=list)
+
+
+class Command(BaseCommand):
+    help = "Recopie les médias de Cloudinary vers le stockage objet OVH (S3)."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            '--dry-run', action='store_true',
+            help="Inventorie les fichiers sans rien transférer.",
+        )
+        parser.add_argument(
+            '--model', action='append', dest='models', default=None,
+            metavar='app.Model',
+            help="Limiter à ce modèle (répétable). Par défaut : tous.",
+        )
+        parser.add_argument(
+            '--overwrite', action='store_true',
+            help="Retransfère même si le fichier existe déjà à destination.",
+        )
+        parser.add_argument(
+            '--limit', type=int, default=0,
+            help="S'arrête après N fichiers transférés (test sur un échantillon).",
+        )
+
+    def handle(self, *args, **options) -> None:
+        source = self._cloudinary_storage()
+        destination = self._s3_storage()
+        report = Report()
+
+        targets = self._targets(options.get('models'))
+        if not targets:
+            raise CommandError('Aucun champ fichier à traiter.')
+
+        self.stdout.write(
+            f"{len(targets)} champ(s) fichier à parcourir"
+            f"{' — DRY RUN' if options['dry_run'] else ''}\n"
+        )
+
+        for model, field_names in targets:
+            self._migrate_model(
+                model, field_names, source, destination, report, options,
+            )
+            if options['limit'] and report.copied >= options['limit']:
+                self.stdout.write(self.style.WARNING(
+                    f"\nLimite de {options['limit']} fichier(s) atteinte."
+                ))
+                break
+
+        self._summarise(report, options['dry_run'])
+
+    # ── Parcours ─────────────────────────────────────────────────
+    def _targets(self, wanted: list[str] | None):
+        """Modèles et champs fichiers à traiter, filtrés par --model."""
+        wanted_lower = {w.lower() for w in wanted} if wanted else None
+        targets = []
+        for model in apps.get_models():
+            if wanted_lower and model._meta.label.lower() not in wanted_lower:
+                continue
+            names = [
+                f.name for f in model._meta.get_fields()
+                if isinstance(f, models.FileField)
+            ]
+            if names:
+                targets.append((model, names))
+
+        if wanted_lower and not targets:
+            raise CommandError(f"Modèle(s) introuvable(s) : {', '.join(wanted)}")
+        return targets
+
+    def _migrate_model(self, model, field_names, source, destination,
+                       report, options) -> None:
+        label = model._meta.label
+        # Ne charger que les lignes ayant au moins un fichier renseigné.
+        query = models.Q()
+        for name in field_names:
+            query |= ~models.Q(**{name: ''}) & models.Q(**{f'{name}__isnull': False})
+
+        queryset = model._default_manager.filter(query).only('pk', *field_names)
+        total = queryset.count()
+        if not total:
+            return
+
+        self.stdout.write(f"{label} ({', '.join(field_names)}) — {total} ligne(s)")
+
+        for instance in queryset.iterator(chunk_size=100):
+            for name in field_names:
+                file_field = getattr(instance, name, None)
+                stored_name = getattr(file_field, 'name', '') or ''
+                if not stored_name:
+                    continue
+                self._transfer(
+                    stored_name, source, destination, report, options,
+                    origin=f'{label}#{instance.pk}.{name}',
+                )
+                if options['limit'] and report.copied >= options['limit']:
+                    return
+
+    def _transfer(self, name, source, destination, report, options,
+                  *, origin: str) -> None:
+        """Transfère un fichier en conservant son chemin exact."""
+        try:
+            if not options['overwrite'] and destination.exists(name):
+                report.skipped += 1
+                return
+        except Exception as exc:  # noqa: BLE001 - backend S3 injoignable
+            report.failed += 1
+            report.errors.append(f'{origin}: destination illisible ({exc})')
+            return
+
+        if options['dry_run']:
+            report.copied += 1
+            self.stdout.write(f"  + {name}")
+            return
+
+        try:
+            payload = self._read(source, name)
+        except FileNotFoundError:
+            # Référence en base sans fichier derrière : fréquent après des
+            # suppressions manuelles côté Cloudinary. On le signale sans
+            # interrompre la migration.
+            report.missing += 1
+            report.errors.append(f'{origin}: absent de la source ({name})')
+            return
+        except Exception as exc:  # noqa: BLE001
+            report.failed += 1
+            report.errors.append(f'{origin}: lecture impossible ({exc})')
+            return
+
+        try:
+            destination.save(name, ContentFile(payload))
+        except Exception as exc:  # noqa: BLE001
+            report.failed += 1
+            report.errors.append(f'{origin}: écriture impossible ({exc})')
+            return
+
+        report.copied += 1
+        self.stdout.write(f"  → {name} ({len(payload) / 1024:.0f} Ko)")
+
+    def _read(self, source, name: str) -> bytes:
+        """Lit le fichier source, par le backend puis par HTTP en secours.
+
+        ``MediaCloudinaryStorage`` n'implémente pas toujours ``open()`` de
+        façon fiable ; l'URL publique, elle, fonctionne toujours.
+        """
+        try:
+            with source.open(name) as handle:
+                payload = handle.read()
+            if payload:
+                return payload
+        except FileNotFoundError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - on tente l'URL publique
+            logger.debug('open() indisponible pour %s (%s) — repli HTTP', name, exc)
+
+        import requests
+
+        url = source.url(name)
+        response = requests.get(url, timeout=60)
+        if response.status_code == 404:
+            raise FileNotFoundError(name)
+        response.raise_for_status()
+        return response.content
+
+    # ── Backends ─────────────────────────────────────────────────
+    def _cloudinary_storage(self):
+        try:
+            from cloudinary_storage.storage import MediaCloudinaryStorage
+        except ImportError as exc:
+            raise CommandError(
+                "django-cloudinary-storage est requis comme source. "
+                "Lancer cette commande avant de retirer Cloudinary."
+            ) from exc
+        return MediaCloudinaryStorage()
+
+    def _s3_storage(self):
+        from django.conf import settings
+
+        if not getattr(settings, 'AWS_STORAGE_BUCKET_NAME', ''):
+            raise CommandError(
+                "Destination non configurée : définir S3_BUCKET_NAME, "
+                "S3_ENDPOINT_URL, S3_ACCESS_KEY_ID et S3_SECRET_ACCESS_KEY."
+            )
+        try:
+            from storages.backends.s3 import S3Storage
+        except ImportError as exc:
+            raise CommandError('django-storages est requis.') from exc
+        return S3Storage()
+
+    # ── Sortie ───────────────────────────────────────────────────
+    def _summarise(self, report: Report, dry_run: bool) -> None:
+        verb = 'à transférer' if dry_run else 'transféré(s)'
+        self.stdout.write('')
+        self.stdout.write(f"  {report.copied} fichier(s) {verb}")
+        self.stdout.write(f"  {report.skipped} déjà présent(s) à destination")
+        if report.missing:
+            self.stdout.write(self.style.WARNING(
+                f"  {report.missing} référence(s) sans fichier source"
+            ))
+        if report.failed:
+            self.stdout.write(self.style.ERROR(f"  {report.failed} échec(s)"))
+
+        for line in report.errors[:20]:
+            self.stdout.write(f"    - {line}")
+        if len(report.errors) > 20:
+            self.stdout.write(f"    … et {len(report.errors) - 20} autre(s)")
+
+        if report.failed:
+            raise CommandError(
+                'Migration incomplète : corriger les échecs puis relancer '
+                '(la commande est idempotente).'
+            )
+        self.stdout.write(self.style.SUCCESS('\nMigration des médias terminée.'))

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,245 @@
+# Migration Render → OVH + Coolify
+
+Runbook de bascule de l'hébergement, motivé par le coût (5 services Render
+facturés) et par les performances (plan *starter* : 512 Mo de RAM et 0,5 vCPU,
+insuffisants pour le rendu PDF WeasyPrint).
+
+**Principe directeur : Render reste en production et intact jusqu'à l'étape 7.**
+Toutes les étapes précédentes sont préparatoires et réversibles. En cas de
+problème après bascule, le retour arrière consiste à remettre le DNS — Render
+n'a pas été touché.
+
+---
+
+## Ce qui change
+
+| | Render | OVH + Coolify |
+|---|---|---|
+| Web | 1 service *starter* (512 Mo) | Conteneur sur VPS 4 vCPU / 12 Go |
+| Tâches planifiées | 3 services facturés | Tâches planifiées Coolify (inclus) |
+| Worker asynchrone | **aucun** | Conteneur `worker` (qcluster) |
+| PostgreSQL | Managé, sauvegardé | Conteneur + sauvegarde vers Object Storage |
+| Redis | **non provisionné** | Conteneur |
+| Médias | Cloudinary | OVH Object Storage |
+| TLS / proxy | Load balancer Render | Traefik intégré à Coolify |
+
+Deux manques de la configuration Render sont corrigés au passage : l'absence de
+Redis (le cache retombait sur LocMem, cloisonné par worker gunicorn, et le
+rate limiting fonctionnait en mode dégradé) et l'absence de worker `qcluster`
+(les tâches censées être asynchrones s'exécutaient en pleine requête HTTP).
+
+---
+
+## 1. Provisionner le VPS
+
+VPS OVH **4 vCPU / 12 Go** (gamme Comfort ou Elite), Debian 12, datacenter
+Gravelines ou Strasbourg.
+
+```bash
+ssh debian@<ip-du-vps>
+sudo apt update && sudo apt upgrade -y
+
+# Pare-feu : seuls SSH, HTTP et HTTPS sont ouverts.
+# Postgres et Redis restent sur le réseau interne Docker.
+sudo apt install -y ufw
+sudo ufw allow 22/tcp && sudo ufw allow 80/tcp && sudo ufw allow 443/tcp
+sudo ufw --force enable
+```
+
+> Le port 8000 n'est **jamais** ouvert : Traefik est le seul point d'entrée.
+
+## 2. Installer Coolify
+
+```bash
+curl -fsSL https://cdn.coollabs.io/coolify/install.sh | sudo bash
+```
+
+L'interface répond ensuite sur `http://<ip-du-vps>:8000`. Créer le compte
+administrateur **immédiatement** — l'inscription est ouverte tant que personne
+ne l'a fait. Activer ensuite la double authentification.
+
+## 3. Créer le stockage objet OVH
+
+Espace client OVH → *Public Cloud* → *Object Storage* → conteneur S3, région
+`gra`, **deux conteneurs** :
+
+- `tus-media` — médias, **accès public en lecture** (servis aux visiteurs) ;
+- `tus-backups` — sauvegardes, **strictement privé**.
+
+Créer un utilisateur S3 et noter la clé d'accès et la clé secrète.
+
+> Vérifier que `tus-backups` est bien privé. Un conteneur de sauvegardes
+> exposé publiquement, c'est toute la base clients — leads, devis, factures —
+> accessible en une URL.
+
+## 4. Déployer la stack dans Coolify
+
+*+ New* → *Docker Compose* → dépôt `beaudelaire1/trait-d-union`, branche `main`,
+fichier `docker-compose.coolify.yml`.
+
+Renseigner les variables d'environnement (onglet *Environment Variables*) :
+
+```bash
+# ── Obligatoires ───────────────────────────────────────────────
+DJANGO_SECRET_KEY=          # openssl rand -base64 48
+POSTGRES_PASSWORD=          # openssl rand -base64 32
+REDIS_PASSWORD=             # openssl rand -base64 32
+POSTGRES_VERSION=16         # DOIT correspondre à la version Render (étape 5)
+
+# ── Domaines ───────────────────────────────────────────────────
+DJANGO_ALLOWED_HOSTS=traitdunion.it,www.traitdunion.it
+CANONICAL_DOMAIN=www.traitdunion.it
+SITE_URL=https://www.traitdunion.it
+
+# ── Médias (OVH Object Storage) ────────────────────────────────
+S3_BUCKET_NAME=tus-media
+S3_ENDPOINT_URL=https://s3.gra.io.cloud.ovh.net
+S3_ACCESS_KEY_ID=
+S3_SECRET_ACCESS_KEY=
+S3_REGION_NAME=gra
+
+# ── Sauvegardes ────────────────────────────────────────────────
+BACKUP_S3_BUCKET=tus-backups
+BACKUP_ENCRYPTION_KEY=      # openssl rand -base64 32 — À CONSERVER HORS DU VPS
+BACKUP_RETENTION_DAYS=30
+
+# ── Secrets repris de Render (Environment → onglet du service web) ──
+BREVO_API_KEY=
+STRIPE_SECRET_KEY=
+STRIPE_PUBLISHABLE_KEY=
+STRIPE_WEBHOOK_SECRET=
+TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=
+RECAPTCHA_SITE_KEY=
+RECAPTCHA_SECRET_KEY=
+GOOGLE_PLACES_API_KEY=
+GOOGLE_PLACE_ID=
+PAGESPEED_API_KEY=
+SENTRY_DSN=
+```
+
+> `BACKUP_ENCRYPTION_KEY` doit être stockée **ailleurs que sur le VPS** (gestionnaire
+> de mots de passe). Perdue, les sauvegardes chiffrées deviennent illisibles —
+> et une sauvegarde conservée à côté de sa clé sur la même machine ne protège
+> pas du scénario qu'elle est censée couvrir.
+
+Ne pas encore associer le domaine de production : déployer d'abord sur le
+sous-domaine temporaire fourni par Coolify, pour valider avant bascule.
+
+## 5. Migrer les données PostgreSQL
+
+Vérifier d'abord la version majeure côté Render — un dump PostgreSQL 16 ne se
+restaure pas dans un PostgreSQL 15 :
+
+```bash
+psql "$RENDER_DATABASE_URL" -c "SELECT version();"
+```
+
+Ajuster `POSTGRES_VERSION` dans Coolify si nécessaire, puis :
+
+```bash
+# Depuis le VPS — dump de la base Render (URL externe, dashboard Render)
+pg_dump --format=custom --no-owner --no-privileges \
+        --file=render.dump "$RENDER_DATABASE_URL"
+
+# Restauration dans le conteneur Postgres de la stack
+docker cp render.dump <conteneur-postgres>:/tmp/render.dump
+docker exec -it <conteneur-postgres> \
+    pg_restore --no-owner --no-privileges --clean --if-exists \
+               -U tus_admin -d traitdunion /tmp/render.dump
+```
+
+Contrôler ensuite que le compte des tables principales correspond à Render :
+
+```bash
+docker exec -it <conteneur-web> python manage.py shell -c "
+from apps.leads.models import Lead
+from apps.devis.models import Quote
+from apps.factures.models import Invoice
+print('leads', Lead.objects.count())
+print('devis', Quote.objects.count())
+print('factures', Invoice.objects.count())
+"
+```
+
+## 6. Migrer les médias
+
+À lancer **pendant que Cloudinary est encore actif** — la commande lit chez
+Cloudinary et écrit chez OVH, sans jamais modifier la base :
+
+```bash
+# Inventaire, sans rien transférer
+docker exec -it <conteneur-web> python manage.py migrate_media_to_s3 --dry-run
+
+# Échantillon de 5 fichiers, pour valider les accès S3
+docker exec -it <conteneur-web> python manage.py migrate_media_to_s3 --limit 5
+
+# Transfert complet (relançable : les fichiers déjà copiés sont ignorés)
+docker exec -it <conteneur-web> python manage.py migrate_media_to_s3
+```
+
+Les chemins stockés en base sont conservés à l'identique. C'est ce qui rend
+l'opération réversible : retirer les variables `S3_*` suffit à revenir à
+Cloudinary.
+
+Garder les variables `CLOUDINARY_*` renseignées pendant toute la migration.
+`config/settings/production.py` donne la priorité à S3 quand les deux sont
+présents — Cloudinary reste donc un filet, sans effet tant que S3 répond.
+
+## 7. Basculer le DNS
+
+Étape irréversible côté visiteurs. Ne la faire qu'après avoir validé le site
+complet sur le sous-domaine temporaire Coolify : page d'accueil, simulateurs,
+génération de PDF, envoi d'un devis, tunnel de paiement Stripe.
+
+1. Associer `traitdunion.it` et `www.traitdunion.it` à la ressource dans
+   Coolify (le certificat Let's Encrypt est émis automatiquement).
+2. Chez le registrar, abaisser le TTL à 300 s **au moins une heure avant**.
+3. Faire pointer l'enregistrement `A` vers l'IP du VPS.
+4. Surveiller la propagation, puis remonter le TTL une fois stabilisé.
+
+Mettre à jour l'URL du webhook Stripe vers le nouveau domaine — c'est l'oubli
+classique : les paiements aboutissent mais les factures ne se marquent jamais
+comme payées.
+
+## 8. Après bascule
+
+- Vérifier les quatre tâches planifiées (voir `scheduled-tasks.md`).
+- Déclencher une sauvegarde manuelle **et tester une restauration** :
+  une sauvegarde jamais restaurée n'est pas une sauvegarde.
+- Laisser Render actif quelques jours, puis supprimer les services.
+
+---
+
+## Restaurer une sauvegarde
+
+```bash
+# Récupérer depuis Object Storage
+aws s3 cp s3://tus-backups/postgres/<fichier>.dump.enc . \
+    --endpoint-url https://s3.gra.io.cloud.ovh.net
+
+# Déchiffrer
+openssl enc -d -aes-256-cbc -pbkdf2 -iter 200000 \
+    -in <fichier>.dump.enc -out restore.dump \
+    -pass pass:"$BACKUP_ENCRYPTION_KEY"
+
+# Restaurer — À FAIRE D'ABORD SUR UNE BASE DE TEST
+docker exec -i <conteneur-postgres> \
+    pg_restore --no-owner --no-privileges --clean --if-exists \
+               -U tus_admin -d traitdunion < restore.dump
+```
+
+> `--clean --if-exists` supprime les tables existantes avant de les recréer.
+> Sur la base de production, cette commande détruit les données actuelles :
+> toujours valider la restauration sur une base jetable avant.
+
+## Retour arrière
+
+Tant que les services Render n'ont pas été supprimés :
+
+1. Remettre l'enregistrement DNS `A` vers Render.
+2. Restaurer l'URL du webhook Stripe.
+
+Les données écrites sur OVH depuis la bascule ne remonteront pas vers Render :
+ce retour arrière n'est propre que dans les premières heures. Passé ce délai,
+mieux vaut réparer la nouvelle installation que revenir en arrière.

--- a/deploy/scheduled-tasks.md
+++ b/deploy/scheduled-tasks.md
@@ -1,0 +1,59 @@
+# Tâches planifiées — équivalent des services cron Render
+
+Sur Render, chaque tâche planifiée était un **service facturé à part** qui
+démarrait un conteneur Docker complet à chaque exécution. Le cas le plus
+coûteux : `resend-reports` tournait toutes les 15 minutes, soit **96 démarrages
+de conteneur par jour** pour une commande qui s'exécute en une seconde.
+
+Sur Coolify, une tâche planifiée s'exécute **dans le conteneur déjà lancé**.
+Ces trois services disparaissent donc de la facture, et une quatrième tâche
+s'ajoute — la sauvegarde de la base, que Render assurait de son côté.
+
+## Configuration dans Coolify
+
+Interface : `Projet → Ressource → Scheduled Tasks → + Add`.
+
+Pour chacune : **Container** = `web`.
+
+| Nom | Commande | Fréquence (cron) |
+|---|---|---|
+| `sync-google-reviews` | `python manage.py sync_google_reviews` | `0 */6 * * *` |
+| `audit-portfolio` | `python manage.py audit_portfolio_projects` | `0 4 * * 1` |
+| `resend-reports` | `python manage.py resend_unsent_simulator_reports` | `*/15 * * * *` |
+| `backup-database` | `python manage.py backup_database` | `30 2 * * *` |
+
+Les horaires sont conservés à l'identique de `render.yaml`, à l'exception de
+la sauvegarde (nouvelle) placée à 02h30 UTC, hors des heures de trafic.
+
+## Pourquoi le conteneur `web` et non `worker`
+
+Les deux conviendraient techniquement. `web` est retenu parce qu'il est le
+seul dont l'indisponibilité est immédiatement visible : si le conteneur ne
+tourne pas, le site est déjà tombé et la tâche manquée n'est pas le problème
+principal. Le `worker` peut, lui, être redémarré ou redimensionné sans que
+cela se voie — une tâche planifiée y serait silencieusement sautée.
+
+## Vérifier après mise en place
+
+```bash
+# Exécution manuelle immédiate, dans le conteneur web
+docker exec -it <conteneur-web> python manage.py resend_unsent_simulator_reports
+
+# La sauvegarde sans rien envoyer, pour valider pg_dump et les accès
+docker exec -it <conteneur-web> python manage.py backup_database --dry-run
+```
+
+Coolify conserve la sortie de chaque exécution dans l'onglet *Scheduled Tasks*.
+À contrôler le lendemain de la bascule : les quatre tâches doivent y afficher
+au moins une exécution réussie.
+
+## Note sur `django-q2`
+
+Le projet utilise `async_task` (`apps/leads`, `apps/einvoicing`, `core/tasks`)
+mais **aucun worker `qcluster` ne tournait sur Render** : `core/tasks.py`
+retombait sur une exécution synchrone, donc en pleine requête HTTP. Le service
+`worker` de `docker-compose.coolify.yml` corrige ce point — les envois d'emails
+et les générations de PDF repassent réellement en arrière-plan.
+
+Ces tâches asynchrones sont distinctes des tâches planifiées ci-dessus : elles
+sont déclenchées par le code, pas par un horaire.

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -1,0 +1,223 @@
+# ==============================================================================
+# Stack de production — OVH VPS + Coolify
+# ==============================================================================
+# Remplace l'infrastructure Render décrite dans render.yaml.
+#
+# Ce que Render facturait comme 5 services distincts tient ici dans une seule
+# stack : web, worker de tâches asynchrones, Postgres et Redis. Les 3 services
+# cron Render sont remplacés par des tâches planifiées Coolify (voir
+# deploy/README.md) qui s'exécutent dans le conteneur `web` déjà lancé.
+#
+# Le TLS, le reverse proxy et le renouvellement Let's Encrypt sont assurés par
+# le Traefik intégré à Coolify : rien à configurer ici.
+#
+# Dimensionné pour un VPS 4 vCPU / 12 Go.
+
+services:
+
+  # ============================================================================
+  # POSTGRESQL
+  # ============================================================================
+  # La version majeure doit correspondre à celle de la base Render dont on
+  # restaure le dump : un dump PG 16 ne se restaure pas dans un PG 15.
+  # Vérifier avec `SELECT version();` sur Render avant la bascule.
+  postgres:
+    image: postgres:${POSTGRES_VERSION:-16}-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-traitdunion}
+      POSTGRES_USER: ${POSTGRES_USER:-tus_admin}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD requis}
+      # Accélère nettement la restauration du dump initial.
+      POSTGRES_INITDB_ARGS: "--data-checksums"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tus_admin} -d ${POSTGRES_DB:-traitdunion}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    # Postgres n'est jamais exposé hors du réseau interne de la stack.
+    networks:
+      - tus
+
+  # ============================================================================
+  # REDIS — cache + rate limiting
+  # ============================================================================
+  # Absent de render.yaml : le cache retombait sur LocMem, cloisonné par worker
+  # gunicorn, et le rate limiting du middleware fonctionnait en mode dégradé.
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: >
+      redis-server
+      --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD requis}
+      --maxmemory 512mb
+      --maxmemory-policy allkeys-lru
+      --appendonly no
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a \"$$REDIS_PASSWORD\" ping | grep -q PONG"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+    networks:
+      - tus
+
+  # ============================================================================
+  # MIGRATIONS — équivalent du preDeployCommand Render
+  # ============================================================================
+  # Conteneur éphémère : il applique les migrations puis s'arrête. `web` et
+  # `worker` attendent sa sortie en succès, ce qui garantit qu'aucun code neuf
+  # ne sert de requêtes sur un schéma non migré.
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: "no"
+    command: ["./build.sh"]
+    environment:
+      <<: &django_env
+        DJANGO_SETTINGS_MODULE: config.settings.production
+        DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:?DJANGO_SECRET_KEY requis}
+        DATABASE_URL: postgresql://${POSTGRES_USER:-tus_admin}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-traitdunion}
+        REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
+        # Redis local en réseau privé : pas de TLS, donc pas de vérification.
+        REDIS_SSL_CERT_REQS: none
+
+        DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-}
+        CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-}
+        CANONICAL_DOMAIN: ${CANONICAL_DOMAIN:-www.traitdunion.it}
+        SITE_URL: ${SITE_URL:-https://www.traitdunion.it}
+
+        # ── Médias : OVH Object Storage (S3) ──────────────────────
+        S3_BUCKET_NAME: ${S3_BUCKET_NAME:-}
+        S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-}
+        S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-}
+        S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-}
+        S3_REGION_NAME: ${S3_REGION_NAME:-gra}
+        S3_CUSTOM_DOMAIN: ${S3_CUSTOM_DOMAIN:-}
+
+        # ── Email (Brevo) ─────────────────────────────────────────
+        BREVO_API_KEY: ${BREVO_API_KEY:-}
+        DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL:-contact@traitdunion.it}
+        DEFAULT_FROM_NAME: ${DEFAULT_FROM_NAME:-Trait d'Union Studio}
+        ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@traitdunion.it}
+        TASK_NOTIFICATION_EMAIL: ${TASK_NOTIFICATION_EMAIL:-info@traitdunion.it}
+
+        # ── Paiements ─────────────────────────────────────────────
+        STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
+        STRIPE_PUBLISHABLE_KEY: ${STRIPE_PUBLISHABLE_KEY:-}
+        STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
+
+        # ── Anti-spam ─────────────────────────────────────────────
+        RECAPTCHA_SITE_KEY: ${RECAPTCHA_SITE_KEY:-}
+        RECAPTCHA_SECRET_KEY: ${RECAPTCHA_SECRET_KEY:-}
+        TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY:-}
+        TURNSTILE_SECRET_KEY: ${TURNSTILE_SECRET_KEY:-}
+        TURNSTILE_FALLBACK_TIMEOUT_MS: ${TURNSTILE_FALLBACK_TIMEOUT_MS:-2500}
+
+        # ── Intégrations ──────────────────────────────────────────
+        GOOGLE_PLACES_API_KEY: ${GOOGLE_PLACES_API_KEY:-}
+        GOOGLE_PLACE_ID: ${GOOGLE_PLACE_ID:-}
+        GOOGLE_REVIEWS_LANGUAGE: ${GOOGLE_REVIEWS_LANGUAGE:-fr}
+        PAGESPEED_API_KEY: ${PAGESPEED_API_KEY:-}
+
+        # ── Observabilité ─────────────────────────────────────────
+        SENTRY_DSN: ${SENTRY_DSN:-}
+        GIT_COMMIT_SHA: ${SOURCE_COMMIT:-unknown}
+
+        # ── Superuser initial (première installation) ─────────────
+        DJANGO_SUPERUSER_USERNAME: ${DJANGO_SUPERUSER_USERNAME:-admin}
+        DJANGO_SUPERUSER_EMAIL: ${DJANGO_SUPERUSER_EMAIL:-admin@traitdunion.it}
+        DJANGO_SUPERUSER_PASSWORD: ${DJANGO_SUPERUSER_PASSWORD:-}
+      # L'audit portfolio fait des appels réseau lents (SSL Labs). Sur Render
+      # il tournait au pre-deploy ; ici il bloquerait le démarrage du site.
+      # La tâche planifiée hebdomadaire s'en charge.
+      SKIP_DEPLOY_AUDIT: "1"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - tus
+
+  # ============================================================================
+  # WEB — Django / Gunicorn
+  # ============================================================================
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    # Coolify (Traefik) route le domaine public vers ce port.
+    expose:
+      - "8000"
+    environment:
+      <<: *django_env
+      # 4 vCPU : 4 workers × 4 threads. WeasyPrint étant gourmand en mémoire
+      # au rendu PDF, on privilégie des workers en nombre modéré plutôt que la
+      # formule (2×CPU)+1, qui multiplierait les pics mémoire simultanés.
+      GUNICORN_WORKERS: ${GUNICORN_WORKERS:-4}
+      GUNICORN_THREADS: ${GUNICORN_THREADS:-4}
+      GUNICORN_TIMEOUT: ${GUNICORN_TIMEOUT:-120}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    networks:
+      - tus
+    deploy:
+      resources:
+        limits:
+          memory: 4g
+
+  # ============================================================================
+  # WORKER — tâches asynchrones (django-q2)
+  # ============================================================================
+  # Absent de l'infrastructure Render : `async_task` était appelé mais aucun
+  # cluster ne tournait. core/tasks.py rattrapait le coup avec un repli
+  # synchrone — les emails et PDF partaient donc en pleine requête HTTP.
+  # Avec ce worker, ils repassent réellement en arrière-plan.
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    command: ["python", "manage.py", "qcluster"]
+    environment:
+      <<: *django_env
+      Q_WORKERS: ${Q_WORKERS:-2}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import django,os;os.environ.setdefault('DJANGO_SETTINGS_MODULE','config.settings.production');django.setup();from django_q.monitor import Stat;exit(0 if Stat.get_all() else 1)\""]
+      interval: 60s
+      timeout: 15s
+      retries: 3
+      start_period: 60s
+    networks:
+      - tus
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+
+volumes:
+  postgres_data:
+  redis_data:
+
+networks:
+  tus:
+    driver: bridge

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,11 @@ dj-database-url>=2.1.0
 # WhiteNoise pour les fichiers statiques (Render)
 whitenoise>=6.6.0
 
-# Stockage Cloudinary pour les médias
+# Stockage des médias
+# django-storages + boto3 : OVH Object Storage (S3-compatible).
+# Cloudinary est conservé le temps de la bascule (voir config/settings/production.py).
+django-storages>=1.14.4
+boto3>=1.34.0
 cloudinary>=1.36.0
 django-cloudinary-storage>=0.3.0
 

--- a/tests/test_backup_database.py
+++ b/tests/test_backup_database.py
@@ -1,0 +1,95 @@
+"""Tests de la commande de sauvegarde PostgreSQL vers le stockage objet.
+
+En auto-hébergeant PostgreSQL (VPS OVH + Coolify), les sauvegardes ne sont plus
+fournies par la plateforme : cette commande devient le seul filet. Sa logique
+de rétention est testée en priorité — une purge trop agressive détruirait les
+sauvegardes qu'elle est censée protéger.
+"""
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from core.management.commands.backup_database import Command
+
+
+def _stamp(days_ago: int) -> str:
+    moment = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=days_ago)
+    return moment.strftime('%Y-%m-%dT%H-%M-%SZ')
+
+
+def _fake_client(keys: list[str]) -> MagicMock:
+    client = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = [
+        {'Contents': [{'Key': key} for key in keys]}
+    ]
+    client.get_paginator.return_value = paginator
+    return client
+
+
+class TestRetention:
+    def _prune(self, keys, retention_days=30):
+        client = _fake_client(keys)
+        command = Command()
+        with patch.object(Command, '_s3_client', return_value=client):
+            removed = command._prune('bucket', 'postgres/', retention_days)
+        deleted = [
+            call.kwargs['Key'] for call in client.delete_object.call_args_list
+        ]
+        return removed, deleted
+
+    def test_deletes_only_backups_past_retention(self):
+        keys = [
+            f'postgres/traitdunion-{_stamp(1)}.dump',    # récent → gardé
+            f'postgres/traitdunion-{_stamp(29)}.dump',   # dans la fenêtre
+            f'postgres/traitdunion-{_stamp(31)}.dump',   # expiré
+            f'postgres/traitdunion-{_stamp(400)}.dump',  # expiré
+        ]
+        removed, deleted = self._prune(keys, retention_days=30)
+
+        assert removed == 2
+        assert all(_stamp(1) not in key and _stamp(29) not in key for key in deleted)
+
+    def test_encrypted_backups_are_recognised(self):
+        keys = [f'postgres/traitdunion-{_stamp(90)}.dump.enc']
+        removed, deleted = self._prune(keys, retention_days=30)
+
+        assert removed == 1, 'les .dump.enc doivent aussi être purgés'
+        assert deleted == keys
+
+    def test_unrelated_objects_are_never_touched(self):
+        """Un objet étranger au préfixe ne doit jamais être supprimé."""
+        keys = [
+            'postgres/notes-importantes.txt',
+            'postgres/traitdunion.dump',            # pas d'horodatage
+            'postgres/media-backup-2020.tar.gz',
+        ]
+        removed, deleted = self._prune(keys, retention_days=1)
+
+        assert removed == 0
+        assert deleted == []
+
+    def test_retention_zero_disables_pruning(self):
+        keys = [f'postgres/traitdunion-{_stamp(999)}.dump']
+        removed, deleted = self._prune(keys, retention_days=0)
+
+        assert removed == 0
+        assert deleted == []
+
+
+class TestGuards:
+    def test_refuses_non_postgres_database(self):
+        """La suite de tests tourne sur SQLite : le refus doit être explicite."""
+        with pytest.raises(CommandError, match='PostgreSQL'):
+            call_command('backup_database', '--dry-run')
+
+    def test_requires_a_destination_bucket(self):
+        with patch.object(Command, '_pg_dump'), \
+             patch('django.conf.settings.AWS_STORAGE_BUCKET_NAME', '', create=True):
+            with pytest.raises(CommandError, match='bucket'):
+                call_command('backup_database', '--bucket', '')

--- a/tests/test_backup_database.py
+++ b/tests/test_backup_database.py
@@ -82,14 +82,47 @@ class TestRetention:
         assert deleted == []
 
 
+# Le moteur est forcé explicitement dans les tests de garde : la suite tourne
+# sur SQLite en local mais sur PostgreSQL en CI. Une garde vérifiée « par
+# hasard », au gré du moteur ambiant, ne prouve rien — c'est ce qui avait fait
+# passer ce test en local puis échouer en CI.
+SQLITE_DB = {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}
+POSTGRES_DB = {
+    'ENGINE': 'django.db.backends.postgresql',
+    'NAME': 'traitdunion', 'HOST': 'db', 'PORT': 5432,
+    'USER': 'tus_admin', 'PASSWORD': 'secret',
+}
+
+
 class TestGuards:
     def test_refuses_non_postgres_database(self):
-        """La suite de tests tourne sur SQLite : le refus doit être explicite."""
-        with pytest.raises(CommandError, match='PostgreSQL'):
+        with (
+            patch.dict('django.conf.settings.DATABASES', {'default': SQLITE_DB}),
+            pytest.raises(CommandError, match='PostgreSQL'),
+        ):
             call_command('backup_database', '--dry-run')
 
+    def test_proceeds_on_postgres(self):
+        """Contrepartie : sur PostgreSQL, la garde ne doit pas bloquer."""
+        with (
+            patch.dict('django.conf.settings.DATABASES', {'default': POSTGRES_DB}),
+            patch.object(Command, '_pg_dump') as dump,
+            patch.object(Command, '_upload'),
+            patch.object(Command, '_prune', return_value=0),
+        ):
+            # _pg_dump est neutralisé : on vérifie qu'il est atteint, pas qu'il
+            # produise un vrai dump (aucun serveur joignable depuis les tests).
+            dump.side_effect = lambda db, path: path.write_bytes(b'PGDMP-stub')
+            call_command('backup_database', '--bucket', 'tus-backups')
+
+        dump.assert_called_once()
+        passed_db = dump.call_args.args[0]
+        assert passed_db['NAME'] == 'traitdunion'
+
     def test_requires_a_destination_bucket(self):
-        with patch.object(Command, '_pg_dump'), \
-             patch('django.conf.settings.AWS_STORAGE_BUCKET_NAME', '', create=True):
-            with pytest.raises(CommandError, match='bucket'):
-                call_command('backup_database', '--bucket', '')
+        with (
+            patch.object(Command, '_pg_dump'),
+            patch('django.conf.settings.AWS_STORAGE_BUCKET_NAME', '', create=True),
+            pytest.raises(CommandError, match='bucket'),
+        ):
+            call_command('backup_database', '--bucket', '')

--- a/tests/test_migrate_media_to_s3.py
+++ b/tests/test_migrate_media_to_s3.py
@@ -1,0 +1,124 @@
+"""Tests de la migration des médias Cloudinary → OVH Object Storage.
+
+Le point critique : le chemin stocké en base ne doit jamais changer. C'est ce
+qui rend la bascule réversible — il suffit d'ajouter ou de retirer les
+variables S3_* pour passer d'un stockage à l'autre.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from apps.chroniques.models import Article
+from core.management.commands.migrate_media_to_s3 import Command
+
+
+@pytest.fixture
+def storages():
+    """Remplace les deux backends par des doubles contrôlables."""
+    source = MagicMock()
+    destination = MagicMock()
+    destination.exists.return_value = False
+    with patch.object(Command, '_cloudinary_storage', return_value=source), \
+         patch.object(Command, '_s3_storage', return_value=destination):
+        yield source, destination
+
+
+def _read_returns(source, payload: bytes):
+    handle = MagicMock()
+    handle.read.return_value = payload
+    source.open.return_value.__enter__.return_value = handle
+
+
+@pytest.mark.django_db
+class TestMediaMigration:
+    def _article(self, cover='chroniques/couverture.jpg'):
+        return Article.objects.create(
+            title='Chronique test',
+            slug='chronique-test',
+            cover_image=cover,
+        )
+
+    def test_preserves_the_stored_path(self, storages):
+        """Le nom écrit à destination est identique à celui de la base."""
+        source, destination = storages
+        article = self._article('chroniques/couverture.jpg')
+        _read_returns(source, b'imagedata')
+
+        call_command('migrate_media_to_s3', '--model', 'chroniques.Article')
+
+        destination.save.assert_called_once()
+        written_name = destination.save.call_args.args[0]
+        assert written_name == 'chroniques/couverture.jpg'
+
+        article.refresh_from_db()
+        assert article.cover_image.name == 'chroniques/couverture.jpg', (
+            'la migration ne doit pas toucher la base'
+        )
+
+    def test_dry_run_transfers_nothing(self, storages):
+        source, destination = storages
+        self._article()
+        _read_returns(source, b'imagedata')
+
+        call_command('migrate_media_to_s3', '--dry-run',
+                     '--model', 'chroniques.Article')
+
+        destination.save.assert_not_called()
+        source.open.assert_not_called()
+
+    def test_existing_destination_file_is_skipped(self, storages):
+        """Idempotence : relancer la commande ne retransfère rien."""
+        source, destination = storages
+        destination.exists.return_value = True
+        self._article()
+
+        call_command('migrate_media_to_s3', '--model', 'chroniques.Article')
+
+        destination.save.assert_not_called()
+
+    def test_overwrite_forces_the_transfer(self, storages):
+        source, destination = storages
+        destination.exists.return_value = True
+        self._article()
+        _read_returns(source, b'imagedata')
+
+        call_command('migrate_media_to_s3', '--overwrite',
+                     '--model', 'chroniques.Article')
+
+        destination.save.assert_called_once()
+
+    def test_missing_source_file_does_not_abort_the_run(self, storages):
+        """Une référence orpheline est signalée, pas fatale."""
+        source, destination = storages
+        self._article()
+        source.open.side_effect = FileNotFoundError('absent')
+        source.url.return_value = 'https://res.cloudinary.com/demo/absent.jpg'
+
+        # Ne lève pas : les orphelins ne sont pas des échecs.
+        call_command('migrate_media_to_s3', '--model', 'chroniques.Article')
+        destination.save.assert_not_called()
+
+    def test_write_failure_is_reported_as_an_error(self, storages):
+        source, destination = storages
+        self._article()
+        _read_returns(source, b'imagedata')
+        destination.save.side_effect = OSError('bucket plein')
+
+        with pytest.raises(CommandError, match='incomplète'):
+            call_command('migrate_media_to_s3', '--model', 'chroniques.Article')
+
+    def test_rows_without_files_are_ignored(self, storages):
+        source, destination = storages
+        Article.objects.create(title='Sans image', slug='sans-image')
+
+        call_command('migrate_media_to_s3', '--model', 'chroniques.Article')
+
+        destination.save.assert_not_called()
+
+    def test_unknown_model_is_rejected(self, storages):
+        with pytest.raises(CommandError, match='introuvable'):
+            call_command('migrate_media_to_s3', '--model', 'inexistant.Modele')


### PR DESCRIPTION
Prépare la bascule de Render vers un VPS OVH 4 vCPU / 12 Go piloté par Coolify. **Aucun changement de comportement sur Render** : tout est additif ou piloté par des variables d'environnement absentes aujourd'hui.

## Pourquoi

| | Render | OVH + Coolify |
|---|---|---|
| Web | 1 service *starter* (512 Mo, 0,5 vCPU) | Conteneur sur VPS 4 vCPU / 12 Go |
| Tâches planifiées | **3 services facturés** | Tâches planifiées Coolify (inclus) |
| Worker asynchrone | **aucun** | Conteneur `worker` (qcluster) |
| PostgreSQL | Managé, sauvegardé | Conteneur + sauvegarde chiffrée vers Object Storage |
| Redis | **non provisionné** | Conteneur |
| Médias | Cloudinary | OVH Object Storage |

Le cron `resend-reports` démarrait à lui seul **96 conteneurs Docker complets par jour** pour une commande qui s'exécute en une seconde.

## Deux manques de la configuration Render corrigés au passage

**Redis n'était jamais provisionné** alors que `production.py` lit `REDIS_URL` : le cache retombait sur LocMem — cloisonné par worker gunicorn, donc largement inefficace — et le rate limiting de `config/middleware.py` fonctionnait en mode dégradé.

**Aucun worker `qcluster` ne tournait**, alors qu'`async_task` est utilisé dans `apps/leads`, `apps/einvoicing` et `core/tasks`. Le repli synchrone de `core/tasks.py` évitait la panne, mais faisait partir les emails et les PDF **en pleine requête HTTP** — ce qui contribue directement à la lenteur ressentie.

## Contenu

**Infrastructure** — `docker-compose.coolify.yml` : web + worker + postgres + redis, avec un conteneur de migration éphémère remplaçant le `preDeployCommand` de Render. `web` et `worker` attendent sa sortie en succès (`service_completed_successfully`), donc aucun code neuf ne sert de requêtes sur un schéma non migré.

**Stockage des médias** — sélection à trois niveaux dans `production.py` : OVH Object Storage si les variables `S3_*` sont présentes, sinon Cloudinary, sinon le disque. L'ordre permet de basculer en ajoutant des variables, sans redéployer deux fois. La CSP suit le stockage choisi, sinon les images seraient bloquées par le navigateur après bascule.

`migrate_media_to_s3` recopie les **17 champs fichiers des 12 modèles** concernés **en conservant le chemin stocké en base**. C'est ce qui rend la bascule réversible : retirer les `S3_*` suffit à revenir à Cloudinary. Idempotente, donc relançable après coupure réseau.

**Sauvegardes** — `backup_database` : `pg_dump` chiffré (AES-256, PBKDF2) poussé vers le stockage objet, avec purge par rétention. Remplace ce que la base managée Render assurait et qui disparaît en auto-hébergement.

**Découplage** — `ALLOWED_HOSTS` n'a plus de domaine de plateforme codé en dur, et `CSRF_TRUSTED_ORIGINS` en est dérivé : déclarer un domaine à deux endroits est une cause classique d'échec CSRF silencieux au déploiement.

**Documentation** — `deploy/README.md` (runbook, Render restant intact jusqu'au changement DNS, restauration et retour arrière) et `deploy/scheduled-tasks.md`.

## Tests

**792 passent**, dont 14 nouveaux ciblant les deux zones où une erreur coûterait cher :
- la **rétention des sauvegardes** — une purge trop large détruirait ce qu'elle protège : vérifié qu'un objet étranger au format n'est jamais supprimé, que les `.dump.enc` sont bien pris en compte, et que `--retention-days 0` désactive la purge ;
- la **préservation des chemins** à la migration des médias, garantie de réversibilité.

`docker-compose.coolify.yml` est validé par `docker compose config` (résolution des variables, ancre YAML partagée, ordre des dépendances). Le démarrage réel de la stack n'a pas pu être testé : pas de démon Docker dans l'environnement de développement.

## Ce qui reste à faire hors dépôt

Provisionner le VPS, installer Coolify, créer les deux conteneurs Object Storage, migrer les données. Le runbook détaille chaque étape.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XD9SLYey3ykz78tU1Hwez8


---
_Generated by [Claude Code](https://claude.ai/code/session_01XD9SLYey3ykz78tU1Hwez8)_

## Summary by Sourcery

Préparez une infrastructure OVH et Coolify réversible pour remplacer progressivement Render tout en sécurisant le stockage, les sauvegardes et les tâches asynchrones.

New Features:
- Ajoutez une stack Docker Compose compatible Coolify pour exécuter l’application avec PostgreSQL, Redis, un worker asynchrone et des migrations contrôlées au démarrage.
- Permettez de choisir automatiquement le stockage des médias entre OVH Object Storage, Cloudinary et le disque local, avec migration réversible des fichiers existants.
- Ajoutez la sauvegarde PostgreSQL chiffrée vers un stockage objet avec gestion de la rétention.
- Rendez les domaines autorisés et les origines CSRF configurables par variables d’environnement.

Bug Fixes:
- Corrigez l’absence de provisioning Redis et de worker qcluster dans l’environnement cible, qui dégradait le cache, le rate limiting et l’exécution des tâches asynchrones.
- Évitez l’exécution de l’audit portfolio pendant le déploiement Coolify lorsqu’il est explicitement désactivé.

Enhancements:
- Rendez le dimensionnement Gunicorn configurable par variables d’environnement et ajoutez les outils nécessaires aux sauvegardes PostgreSQL.
- Ajoutez un runbook de migration, de restauration, de retour arrière et de configuration des tâches planifiées Coolify.

Deployment:
- Préparez la migration de l’hébergement Render vers un VPS OVH piloté par Coolify sans modifier le comportement existant de Render.

Documentation:
- Documentez la procédure de déploiement, les tâches planifiées, la migration des données et les opérations de restauration.

Tests:
- Ajoutez des tests pour la rétention des sauvegardes et la préservation des chemins lors de la migration des médias.